### PR TITLE
Remove console.error and fix build warning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": ["next", "next/core-web-vitals", "plugin:prettier/recommended"]
+  "extends": ["next", "next/core-web-vitals", "plugin:prettier/recommended"],
+  "rules": {
+    "no-console": 2
+  }
 }

--- a/components/leaderboard/LeaderboardRow.tsx
+++ b/components/leaderboard/LeaderboardRow.tsx
@@ -53,7 +53,6 @@ type Props = {
 
 function LeaderboardRow({ id, rank, graffiti, points }: Props) {
   const avatarColor = getColor(graffiti)
-  console.error(avatarColor)
   const rankStr = ordinalSuffix(rank)
   const pointsStr = points.toLocaleString()
 

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -69,7 +69,10 @@ export default function Leaderboard({ users }: Props) {
             <div className="border-r border-black flex h-full items-center justify-between px-5">
               <label className="flex flex-col font-favorit text-xs">
                 Region:
-                <input className="text-lg bg-transparent" value="Global" />
+                <input
+                  className="text-lg bg-transparent"
+                  placeholder="Global"
+                />
               </label>
               <Image
                 src="/arrow_drop_down_black.png"
@@ -84,7 +87,7 @@ export default function Leaderboard({ users }: Props) {
                 View:
                 <input
                   className="text-lg bg-transparent"
-                  value="Total Points"
+                  placeholder="Total Points"
                 />
               </label>
               <Image


### PR DESCRIPTION
Removes a console.error that was left in the code, and fixes the following warning on the leaderboard page:

```
Warning: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.
    at input
    at label
    at div
    at div
    at div
    at main
    at div
    at Leaderboard (webpack-internal:///./pages/leaderboard.tsx:44:3)
    at MyApp (webpack-internal:///./pages/_app.tsx:18:3)
    at AppContainer (/Users/derek/repos/website-testnet/node_modules/next/dist/next-server/server/render.js:27:952)
```
