### PR TITLE
IRO-940 company cube alignment

### DIFF
--- a/components/Navbar/Company.tsx
+++ b/components/Navbar/Company.tsx
@@ -1,44 +1,12 @@
 import React from 'react'
 
-import Cube from './Cube'
 import Link from 'next/link'
-
-type SectionHeaderProps = {
-  children?: React.ReactNode
-  className?: string
-}
-
-const SectionHeader = ({ children, className }: SectionHeaderProps) => (
-  <h3 className={`font-favorit text-ifgray text-sm mb-7 ${className}`}>
-    {children}
-  </h3>
-)
-
-type TestnetGridElementProps = {
-  header: string
-  href: string
-  body: string
-  cubeClassName: string
-}
-
-const TestnetGridElement = ({
-  href,
-  header,
-  body,
-  cubeClassName,
-}: TestnetGridElementProps) => (
-  <Link href={href}>
-    <a className="flex items-center mr-2 lg:mr-4 p-2 lg:p-4 rounded hover:bg-iflightgray">
-      <Cube className={cubeClassName} />
-      <div className="flex flex-col ml-2 lg:ml-4">
-        <h5>{header}</h5>
-        <p className="font-favorit text-ifgray text-sm">{body}</p>
-      </div>
-    </a>
-  </Link>
-)
+import TestnetGridElement from './TestnetGridElement'
+import SectionHeader from './SectionHeader'
 
 function Company() {
+  const elementClassName = `mr-2 lg:mr-4 p-2 lg:p-4`
+  const textClassName = `ml-2 lg:ml-4`
   return (
     <div className="absolute bg-white left-0 right-0 shadow-navbar">
       <div className="flex flex-col items-center border-b border-t p-8 pb-10">
@@ -50,24 +18,32 @@ function Company() {
                 href="https://ironfish.network/about"
                 header="About Us"
                 body="Learn who Iron Fish is"
+                className={`${elementClassName} -ml-2.5`}
+                textClassName={textClassName}
                 cubeClassName="text-iforange"
               />
               <TestnetGridElement
                 href="https://ironfish.network/careers"
                 header="Careers"
                 body="We're hiring!"
+                className={elementClassName}
+                textClassName={textClassName}
                 cubeClassName="text-ifbeige"
               />
               <TestnetGridElement
                 href="https://ironfish.network/blog"
                 header="Blog"
                 body="What we've got to say"
+                className={elementClassName}
+                textClassName={textClassName}
                 cubeClassName="text-ifcubepink"
               />
               <TestnetGridElement
                 href="https://ironfish.network/faq"
                 header="FAQ"
                 body="Frequently asked questions"
+                className={elementClassName}
+                textClassName={textClassName}
                 cubeClassName="text-iflightblue"
               />
             </div>

--- a/components/Navbar/SectionHeader.tsx
+++ b/components/Navbar/SectionHeader.tsx
@@ -1,0 +1,12 @@
+type SectionHeaderProps = {
+  children?: React.ReactNode
+  className?: string
+}
+
+const SectionHeader = ({ children, className }: SectionHeaderProps) => (
+  <h3 className={`font-favorit text-ifgray text-sm mb-7 ${className}`}>
+    {children}
+  </h3>
+)
+
+export default SectionHeader

--- a/components/Navbar/Testnet.tsx
+++ b/components/Navbar/Testnet.tsx
@@ -1,44 +1,9 @@
-import React from 'react'
-
-import Cube from './Cube'
-import Link from 'next/link'
-
-type SectionHeaderProps = {
-  children?: React.ReactNode
-  className?: string
-}
-
-const SectionHeader = ({ children, className }: SectionHeaderProps) => (
-  <h3 className={`font-favorit text-ifgray text-sm mb-7 ${className}`}>
-    {children}
-  </h3>
-)
-
-type TestnetGridElementProps = {
-  header: string
-  href: string
-  body: string
-  cubeClassName: string
-}
-
-const TestnetGridElement = ({
-  href,
-  header,
-  body,
-  cubeClassName,
-}: TestnetGridElementProps) => (
-  <Link href={href}>
-    <a className="flex items-center py-4 px-6 rounded hover:bg-iflightgray">
-      <Cube className={cubeClassName} />
-      <div className="flex flex-col ml-4">
-        <h5>{header}</h5>
-        <p className="font-favorit text-ifgray text-sm">{body}</p>
-      </div>
-    </a>
-  </Link>
-)
+import TestnetGridElement from './TestnetGridElement'
+import SectionHeader from './SectionHeader'
 
 function Testnet() {
+  const elementClassName = `py-4 px-6`
+  const textClassName = `ml-4`
   return (
     <div className="absolute bg-white left-0 right-0 shadow-navbar">
       <div className="flex justify-center border-b border-t">
@@ -66,24 +31,32 @@ function Testnet() {
                 href="/about"
                 header="About the Testnet"
                 body="How to earn points"
+                className={elementClassName}
+                textClassName={textClassName}
                 cubeClassName="text-iforange"
               />
               <TestnetGridElement
                 href="/community"
                 header="Testnet Community"
                 body="From our supporters"
+                className={elementClassName}
+                textClassName={textClassName}
                 cubeClassName="text-ifbeige"
               />
               <TestnetGridElement
                 href="/leaderboard"
                 header="Testnet Leaderboard"
                 body="Earn your way to the top"
+                className={elementClassName}
+                textClassName={textClassName}
                 cubeClassName="text-ifcubepink"
               />
               <TestnetGridElement
                 href="/faq"
                 header="Testnet FAQ"
                 body="Frequently asked questions"
+                className={elementClassName}
+                textClassName={textClassName}
                 cubeClassName="text-iflightblue"
               />
             </div>

--- a/components/Navbar/TestnetGridElement.tsx
+++ b/components/Navbar/TestnetGridElement.tsx
@@ -1,0 +1,34 @@
+import Cube from './Cube'
+import Link from 'next/link'
+
+type TestnetGridElementProps = {
+  header: string
+  href: string
+  body: string
+  cubeClassName: string
+  className?: string
+  textClassName: string
+}
+
+const TestnetGridElement = ({
+  className,
+  href,
+  header,
+  body,
+  cubeClassName,
+  textClassName,
+}: TestnetGridElementProps) => (
+  <Link href={href}>
+    <a
+      className={`flex items-center ${className} rounded hover:bg-iflightgray`}
+    >
+      <Cube className={cubeClassName} />
+      <div className={`flex flex-col ${textClassName}`}>
+        <h5>{header}</h5>
+        <p className="font-favorit text-ifgray text-sm">{body}</p>
+      </div>
+    </a>
+  </Link>
+)
+
+export default TestnetGridElement


### PR DESCRIPTION
1. Core change is one of CSS alignment:

<img width="213" alt="Screen Shot 2021-08-17 at 12 28 36" src="https://user-images.githubusercontent.com/18919/129808982-6806a5c5-4075-488b-b042-b9e1fcac468e.png">

2. Secondary changes are to make things more DRY (namely reusing `SectionHeader` + `TestnetGridElement` and making them standalone files)