### PR TITLE
Fix leaderboard due to API changes

### DIFF
--- a/apiClient/index.ts
+++ b/apiClient/index.ts
@@ -75,7 +75,7 @@ export type MetricsConfigResponse = {
 export async function listLeaderboard(): Promise<
   ListLeaderboardResponse | ApiError
 > {
-  const res = await fetch(`${API_URL}/users?order_by=total_points`)
+  const res = await fetch(`${API_URL}/users?order_by=rank`)
   return await res.json()
 }
 

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -111,7 +111,7 @@ export default function Leaderboard({ users }: Props) {
               <div key={user.id} className="mb-3">
                 <LeaderboardRow
                   id={user.id}
-                  rank={i + 1}
+                  rank={user.rank}
                   graffiti={user.graffiti}
                   points={user.total_points}
                 />


### PR DESCRIPTION
There were a few changes on the backend to the users API involving the ranking, so this brings it up to date so the page works again.
