### PR TITLE
IRO-1013 - Remove unwanted padding on Signup + Login

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -104,10 +104,10 @@ export default function Login() {
       <Navbar fill="black" className="bg-ifpink text-black" />
 
       <main className="bg-ifpink flex-1 font-extended">
-        <div className="md:w-4/5 w-full max-w-section my-16 mx-auto transition-width">
+        <div className="md:w-4/5 w-full my-6 max-w-section mx-auto transition-width">
           <OffsetBorderContainer>
             <div className="flex justify-center">
-              <div className="flex flex-col items-center md:px-4 px-5 pb-16">
+              <div className="flex flex-col items-center md:px-4 px-5">
                 {$loaded ? (
                   <>
                     <h1 className="text-4xl text-center mb-4 mt-16">

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -135,11 +135,11 @@ export default function SignUp() {
       </Head>
       <Navbar fill="black" className="bg-ifpink text-black" />
       <main className="bg-ifpink flex-1 font-extended">
-        <div className="md:w-4/5 w-full max-w-section my-16 mx-auto transition-width">
+        <div className="md:w-4/5 w-full my-6 max-w-section mx-auto transition-width">
           <OffsetBorderContainer>
             <div
               style={{ minHeight: '43rem', maxWidth: '53.5rem' }}
-              className="flex flex-col m-auto h-auto items-center mt-8 px-5 pb-16"
+              className="flex flex-col m-auto h-auto items-center mt-8 px-5 pb-2"
             >
               {!$loaded ? (
                 <Loader />


### PR DESCRIPTION
<img width="902" alt="Screen Shot 2021-08-30 at 9 11 17 AM" src="https://user-images.githubusercontent.com/18919/131392181-e5bc7e1d-d8e1-4f88-a2fb-d7eb1e669790.png">

I _think_ this is all in line with Skylar's feedback. I added a tiny bit of margin back so that the offset box didn't crash into the header / footer.