### PR TITLE
IRO-1026 menu-padding

### DIFF
--- a/components/Navbar/Flyout.tsx
+++ b/components/Navbar/Flyout.tsx
@@ -28,7 +28,7 @@ export function NavbarFlyout({
   return (
     <div
       className={`absolute z-20 h-screen w-screen bg-white text-black font-extended transition-all transform-gpu overflow-y-auto ${
-        !flyoutVisible ? '-translate-x-full pb-6' : 'pb-24'
+        !flyoutVisible ? '-translate-x-full pb-6' : 'pb-32'
       } md:hidden`}
     >
       <div className="flex flex-col px-5 max-w-xl mx-auto">


### PR DESCRIPTION
Made it so scrolling to the bottom of the menu is possible. I originally thought it was a difference in behavior between browsers, but it's actually just difference in browser UI height.

![IMG_3DBA08E61C86-1](https://user-images.githubusercontent.com/18919/131579337-ee45a150-e90c-4f7e-aafe-845ff7889633.jpeg)
