### PR TITLE
IRO-894 Hook up search field

### DIFF
--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -45,10 +45,16 @@ export async function createUser(
   return await res.json()
 }
 
-export async function listLeaderboard(): Promise<
-  ListLeaderboardResponse | ApiError
-> {
-  const res = await fetch(`${API_URL}/users?order_by=rank`)
+export async function listLeaderboard({
+  search,
+}: {
+  search?: string
+} = {}): Promise<ListLeaderboardResponse | ApiError> {
+  const params = new URLSearchParams({ order_by: 'rank' })
+  if (search) {
+    params.append('search', search)
+  }
+  const res = await fetch(`${API_URL}/users?${params.toString()}`)
   return await res.json()
 }
 

--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+export function useDebounce<T>(value: T, timeoutMs: number): T {
+  const [$debouncedValue, $setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      $setDebouncedValue(value)
+    }, timeoutMs)
+
+    return () => {
+      clearTimeout(handle)
+    }
+  }, [value, timeoutMs])
+
+  return $debouncedValue
+}
+
+export default useDebounce


### PR DESCRIPTION
Hooks up a basic debounced API call to the search endpoint. The initial data fetch is done by the server, then searches are done on the client.

## Todo

The API endpoint for listing users doesn't currently allow for ordering by rank when searching -- created [IRO-1051](https://linear.app/ironfish/issue/IRO-1051/allow-ordering-by-rank-when-users-are-filtered) for this.