### PR TITLE
IRO-1066 - About Page: Leaderboard Section

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -93,7 +93,7 @@ export default function About() {
             </div>
           </div>
           <AboutHeader className="md:w-1/2 mt-48">The Leaderboard</AboutHeader>
-          <p className="w-full md:w-2/3">
+          <p className="w-full md:w-2/3 text-2xl">
             Not only does earning points help you climb the Leaderboard, but the
             more points you have means the more $IRON you redeem at the end of
             the testnet. Placing in the top 10 also earns you bonus points!


### PR DESCRIPTION
- [x] Fixes IRO-1066 - Leaderboard Section
- [x] Fixes IRO-1067 - Make "Leaderboard title" have 12rem top margin
- [x] Fixes IRO-1068 - Paragraph under h2, 24px font size, 32px line height.
- [x] Fixes IRO-1069 - "Show me the leaderboard" text link, margin top total 32px.
