### PR TITLE
IRO-881 Hide dropshadow above the subnav

### DIFF
--- a/components/Navbar/Company.tsx
+++ b/components/Navbar/Company.tsx
@@ -15,7 +15,10 @@ function Company({ condensed = false }: CompanyProps) {
     : 'absolute bg-white left-0 right-0 shadow-navbar z-10 top-5.5'
   return (
     <div className="flex">
-      <div className={className}>
+      <div
+        className={className}
+        style={{ clipPath: !condensed ? 'inset(0 0 -100% 0)' : undefined }}
+      >
         <div
           className={`flex flex-col ${
             condensed

--- a/components/Navbar/Testnet.tsx
+++ b/components/Navbar/Testnet.tsx
@@ -15,7 +15,10 @@ function Testnet({ condensed = false }: TestnetProps) {
     : 'absolute bg-white left-0 right-0 shadow-navbar z-20 top-5.5'
   return (
     <div className="flex">
-      <div className={className}>
+      <div
+        className={className}
+        style={{ clipPath: !condensed ? 'inset(0 0 -100% 0)' : undefined }}
+      >
         <div
           className={`flex justify-center ${
             condensed ? 'flex-col' : 'border-b border-t flex-row'


### PR DESCRIPTION
Clips the top shadow off of the subnav in desktop view so that it appears to be part of the main nav.

I don't know that there's a super clean way of handling this, but it seems to work in Chrome and Safari. Other fixes I've seen include tweaking the offsets and radiuses to move the shadow around, and using z-index to place divs over top of the parts you want to cover.
