### PR TITLE
IRO-1156 Sign Up page's Testnet Guidelines should link to page

### DIFF
--- a/components/signup/FinePrint.tsx
+++ b/components/signup/FinePrint.tsx
@@ -1,6 +1,11 @@
+import Link from 'next/link'
+
 export const FinePrint = () => (
   <span className="font-favorit p-2 max-w-md text-sm text-center">
-    By clicking on sign up, you agree to Iron Fish&apos;s Testnet Guidelines.
+    By clicking on sign up, you agree to Iron Fish&apos;s{' '}
+    <Link href="/about#guidelines">
+      <a className="text-iflightblue">Testnet Guidelines.</a>
+    </Link>
   </span>
 )
 export default FinePrint


### PR DESCRIPTION
Changes the Testnet Guidelines subtext on the Signup page to a link.
