### PR TITLE
Hide settings tab on non-authed user page

### DIFF
--- a/components/user/Tabs/SettingsContent.tsx
+++ b/components/user/Tabs/SettingsContent.tsx
@@ -7,40 +7,40 @@ import { useField } from 'hooks/useForm'
 import { FIELDS } from 'pages/signup'
 
 type Props = {
-  userMetadata: API.ApiUserMetadata
+  authedUser: API.ApiUserMetadata
 }
 
 const getSocialChoice = (
-  userMetaData: API.ApiUserMetadata
+  authedUser: API.ApiUserMetadata
 ): { choice: string; value: string } => {
-  if (userMetaData.discord) {
-    return { choice: 'discord', value: userMetaData.discord }
-  } else if (userMetaData.telegram) {
-    return { choice: 'telegram', value: userMetaData.telegram }
+  if (authedUser.discord) {
+    return { choice: 'discord', value: authedUser.discord }
+  } else if (authedUser.telegram) {
+    return { choice: 'telegram', value: authedUser.telegram }
   }
   return { choice: '', value: '' }
 }
 
-export default function SettingsContent({ userMetadata }: Props) {
+export default function SettingsContent({ authedUser }: Props) {
   const $email = useField(FIELDS.email)
   const $graffiti = useField(FIELDS.graffiti)
   const $social = useField(FIELDS.social)
   const $country = useField(FIELDS.country)
 
   const { choice: socialChoice, value: socialValue } =
-    getSocialChoice(userMetadata)
+    getSocialChoice(authedUser)
 
   return (
     <div className="flex">
       <div className="flex-initial">
         <div className="font-favorit mt-8">User Settings</div>
         {$email && (
-          <TextField {...$email} defaultValue={userMetadata.email} disabled />
+          <TextField {...$email} defaultValue={authedUser.email} disabled />
         )}
         {$graffiti && (
           <TextField
             {...$graffiti}
-            defaultValue={userMetadata.graffiti}
+            defaultValue={authedUser.graffiti}
             disabled
           />
         )}
@@ -53,7 +53,7 @@ export default function SettingsContent({ userMetadata }: Props) {
           />
         )}
         {$country && (
-          <Select {...$country} disabled value={userMetadata.country_code} />
+          <Select {...$country} disabled value={authedUser.country_code} />
         )}
       </div>
     </div>

--- a/components/user/Tabs/index.tsx
+++ b/components/user/Tabs/index.tsx
@@ -12,7 +12,8 @@ type TabsProps = {
   allTimeMetrics: API.UserMetricsResponse
   weeklyMetrics: API.UserMetricsResponse
   metricsConfig: API.MetricsConfigResponse
-  userMetadata: API.ApiUserMetadata | null
+  user: API.ApiUser
+  authedUser: API.ApiUserMetadata | null
   activeTab: TabType
   onTabChange: (tab: TabType) => unknown
 }
@@ -21,7 +22,8 @@ export default function Tabs({
   allTimeMetrics,
   weeklyMetrics,
   metricsConfig,
-  userMetadata,
+  user,
+  authedUser,
   activeTab,
   onTabChange,
 }: TabsProps) {
@@ -41,7 +43,7 @@ export default function Tabs({
         >
           All Time Stats
         </TabHeaderButton>
-        {userMetadata && (
+        {authedUser && user.id === authedUser.id && (
           <TabHeaderButton
             selected={activeTab === 'settings'}
             onClick={() => onTabChange('settings')}
@@ -61,8 +63,8 @@ export default function Tabs({
       {activeTab === 'all' && (
         <AllTimeContent allTimeMetrics={allTimeMetrics} />
       )}
-      {activeTab === 'settings' && userMetadata && (
-        <SettingsContent userMetadata={userMetadata} />
+      {activeTab === 'settings' && authedUser && (
+        <SettingsContent authedUser={authedUser} />
       )}
     </div>
   )

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -192,7 +192,8 @@ export default function User({
                     <Tabs
                       activeTab={$activeTab}
                       onTabChange={onTabChange}
-                      userMetadata={metadata}
+                      user={user}
+                      authedUser={metadata}
                       allTimeMetrics={allTimeMetrics}
                       weeklyMetrics={weeklyMetrics}
                       metricsConfig={metricsConfig}


### PR DESCRIPTION
The settings tab currently shows up on every user page when you're logged in, which led to some confusion around whether you're viewing settings for that user or for the logged-in user. This change makes it only appear when the authed user ID matches the user page's user ID.

I renamed a bunch of props here to what I thought was more clear, I'm fine rolling those renames back if it doesn't seem like an improvement 👍 

Fixes #119 