### PR TITLE
IRO-1402: Fields can set whitespace controls

### DIFF
--- a/components/Form/TextField.tsx
+++ b/components/Form/TextField.tsx
@@ -64,35 +64,40 @@ export const TextField = ({
   isRadioed,
   disabled,
   autotrim,
-}: Field) => (
-  <LabelledRow
-    key={id}
-    id={id}
-    label={label}
-    valid={valid}
-    errorText={errorText}
-    disabled={disabled}
-  >
-    {isRadioed && options.length > 0 && (
-      <RadioOptions
-        disabled={disabled}
-        groupName={`${id}-group`}
-        options={options}
-        choice={choice}
-        setChoice={setChoice}
-      />
-    )}
-    <input
-      className={`${disabled ? 'bg-transparent' : ''}`}
-      defaultValue={defaultValue}
-      disabled={disabled}
-      onBlur={onBlur}
-      onChange={onChange}
-      {...(autotrim ? { onKeyDown } : {})}
+}: Field) => {
+  const handleTrim = autotrim ? { onKeyDown } : {}
+  // eslint-disable-next-line no-console
+  console.log({ handleTrim, autotrim })
+  return (
+    <LabelledRow
+      key={id}
       id={id}
-      type="text"
-      placeholder={placeholder}
-    />
-  </LabelledRow>
-)
+      label={label}
+      valid={valid}
+      errorText={errorText}
+      disabled={disabled}
+    >
+      {isRadioed && options.length > 0 && (
+        <RadioOptions
+          disabled={disabled}
+          groupName={`${id}-group`}
+          options={options}
+          choice={choice}
+          setChoice={setChoice}
+        />
+      )}
+      <input
+        className={`${disabled ? 'bg-transparent' : ''}`}
+        defaultValue={defaultValue}
+        disabled={disabled}
+        onBlur={onBlur}
+        onChange={onChange}
+        {...handleTrim}
+        id={id}
+        type="text"
+        placeholder={placeholder}
+      />
+    </LabelledRow>
+  )
+}
 export default TextField

--- a/components/Form/TextField.tsx
+++ b/components/Form/TextField.tsx
@@ -56,6 +56,7 @@ export const TextField = ({
   defaultValue,
   valid,
   onChange,
+  onKeyDown,
   onBlur,
   options = [],
   choice,
@@ -87,10 +88,10 @@ export const TextField = ({
       disabled={disabled}
       onBlur={onBlur}
       onChange={onChange}
+      {...(autotrim ? { onKeyDown } : {})}
       id={id}
       type="text"
       placeholder={placeholder}
-      {...(autotrim ? { pattern: '\\S+' } : {})}
     />
   </LabelledRow>
 )

--- a/components/Form/TextField.tsx
+++ b/components/Form/TextField.tsx
@@ -1,6 +1,6 @@
 import styles from './index.module.css'
 import { Dispatch, SetStateAction } from 'react'
-import { Field, NameValue } from 'hooks/useForm'
+import { Field, NameValue, WHITESPACE } from 'hooks/useForm'
 import LabelledRow from './LabelledRow'
 
 interface OptionsProps {
@@ -63,11 +63,11 @@ export const TextField = ({
   setChoice,
   isRadioed,
   disabled,
-  autotrim,
+  whitespace = WHITESPACE.DEFAULT,
 }: Field) => {
-  const handleTrim = autotrim ? { onKeyDown } : {}
+  const handleTrim = whitespace !== WHITESPACE.DEFAULT ? { onKeyDown } : {}
   // eslint-disable-next-line no-console
-  console.log({ handleTrim, autotrim })
+  console.log({ handleTrim, whitespace })
   return (
     <LabelledRow
       key={id}

--- a/components/Form/TextField.tsx
+++ b/components/Form/TextField.tsx
@@ -66,8 +66,6 @@ export const TextField = ({
   whitespace = WHITESPACE.DEFAULT,
 }: Field) => {
   const handleTrim = whitespace !== WHITESPACE.DEFAULT ? { onKeyDown } : {}
-  // eslint-disable-next-line no-console
-  console.log({ handleTrim, whitespace })
   return (
     <LabelledRow
       key={id}

--- a/components/Form/TextField.tsx
+++ b/components/Form/TextField.tsx
@@ -62,6 +62,7 @@ export const TextField = ({
   setChoice,
   isRadioed,
   disabled,
+  autotrim,
 }: Field) => (
   <LabelledRow
     key={id}
@@ -89,6 +90,7 @@ export const TextField = ({
       id={id}
       type="text"
       placeholder={placeholder}
+      {...(autotrim ? { pattern: '\\S+' } : {})}
     />
   </LabelledRow>
 )

--- a/components/ResponsiveToolkit/index.tsx
+++ b/components/ResponsiveToolkit/index.tsx
@@ -66,8 +66,6 @@ const ResponsiveToolkit = ({ userDetails }: ResponsiveToolkitProps) => {
     const update = () => {
       $setWidth(window.innerWidth)
       const newPoints = activePoints()
-      // eslint-disable-next-line no-console
-      console.log({ points: newPoints, $customPoint })
       $setPoint(newPoints)
     }
     if ($toolkit) {

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -1,4 +1,10 @@
-import { useEffect, useState, ChangeEvent, KeyboardEventHandler } from 'react'
+import {
+  useEffect,
+  useState,
+  ChangeEvent,
+  KeyboardEvent,
+  KeyboardEventHandler,
+} from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { setStateOnChange } from 'utils/forms'
 
@@ -67,14 +73,11 @@ export function useField(provided: ProvidedField): Field | null {
       autotrim,
       setValid: $setValid,
       setter: $setter,
-      onKeyDown: e => {
-        // eslint-disable-next-line
-        console.log({
-          // @ts-ignore
-          value: (e && e.target && e.target.value) || 'nothing set',
-          event: e,
-          key: e.key,
-        })
+      onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+        // f ts
+        const { value = '' } = e.target as HTMLTextAreaElement
+        // eslint-disable-next-line no-console
+        console.log({ value, key: e.key, sel: window.getSelection() })
         if (autotrim && e.key === ' ') {
           e.preventDefault()
         }

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -77,7 +77,11 @@ export function useField(provided: ProvidedField): Field | null {
         // f ts
         const { value = '' } = e.target as HTMLTextAreaElement
         // eslint-disable-next-line no-console
-        console.log({ value, key: e.key, sel: window.getSelection() })
+        console.log({
+          value,
+          key: e.key,
+          sel: window?.getSelection()?.getRangeAt(0),
+        })
         if (autotrim && e.key === ' ') {
           e.preventDefault()
         }

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -64,6 +64,7 @@ export function useField(provided: ProvidedField): Field | null {
       defaultValue,
       value: $value,
       valid,
+      autotrim,
       setValid: $setValid,
       setter: $setter,
       onKeyDown: e => {

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -82,15 +82,6 @@ export function useField(provided: ProvidedField): Field | null {
       setValid: $setValid,
       setter: $setter,
       onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
-        // f ts
-        const { value = '' } = e?.target as HTMLTextAreaElement
-        // const selected = window?.getSelection()?.getRangeAt(0) || 'no idea'
-        // eslint-disable-next-line no-console
-        console.log({
-          value,
-          key: e.key,
-          // selected,
-        })
         if (banSpaces && e.key === ' ') {
           e.preventDefault()
         }

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -75,13 +75,13 @@ export function useField(provided: ProvidedField): Field | null {
       setter: $setter,
       onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
         // f ts
-        const { value = '' } = e.target as HTMLTextAreaElement
-        const selected = window?.getSelection()?.getRangeAt(0) || 'no idea'
+        const { value = '' } = e?.target as HTMLTextAreaElement
+        // const selected = window?.getSelection()?.getRangeAt(0) || 'no idea'
         // eslint-disable-next-line no-console
         console.log({
           value,
           key: e.key,
-          selected,
+          // selected,
         })
         if (autotrim && e.key === ' ') {
           e.preventDefault()

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, ChangeEvent } from 'react'
+import { useEffect, useState, ChangeEvent, KeyboardEventHandler } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { setStateOnChange } from 'utils/forms'
 
@@ -25,6 +25,7 @@ export interface Field extends ProvidedField {
   setter: Dispatch<SetStateAction<string>>
   setValid: Dispatch<SetStateAction<boolean>>
   onChange: (e: ChangeEvent) => void
+  onKeyDown: KeyboardEventHandler<HTMLInputElement>
   onBlur: () => void
   valid: boolean
   setTouched: Dispatch<SetStateAction<boolean>>
@@ -65,6 +66,13 @@ export function useField(provided: ProvidedField): Field | null {
       valid,
       setValid: $setValid,
       setter: $setter,
+      onKeyDown: e => {
+        // eslint-disable-next-line
+        console.log({ event: e, key: e.key })
+        if (autotrim && e.key === ' ') {
+          e.preventDefault()
+        }
+      },
       onChange: setStateOnChange($setter, autotrim),
       onBlur: () => {
         $setTouched(true)

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -76,11 +76,12 @@ export function useField(provided: ProvidedField): Field | null {
       onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
         // f ts
         const { value = '' } = e.target as HTMLTextAreaElement
+        const selected = window?.getSelection()?.getRangeAt(0) || 'no idea'
         // eslint-disable-next-line no-console
         console.log({
           value,
           key: e.key,
-          sel: window?.getSelection()?.getRangeAt(0),
+          selected,
         })
         if (autotrim && e.key === ' ') {
           e.preventDefault()

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -16,6 +16,7 @@ export interface ProvidedField {
   isRadioed?: boolean
   options?: NameValue[]
   defaultErrorText?: string
+  autotrim?: boolean
 }
 export interface Field extends ProvidedField {
   value: string
@@ -42,6 +43,7 @@ export function useField(provided: ProvidedField): Field | null {
     provided.options &&
     provided.options[0] &&
     provided.options[0].value
+  const { autotrim = true } = provided
   const [$choice, $setChoice] = useState<string>(
     provided.isRadioed && radioOption ? radioOption : ''
   )
@@ -63,7 +65,7 @@ export function useField(provided: ProvidedField): Field | null {
       valid,
       setValid: $setValid,
       setter: $setter,
-      onChange: setStateOnChange($setter),
+      onChange: setStateOnChange($setter, autotrim),
       onBlur: () => {
         $setTouched(true)
       },
@@ -85,6 +87,7 @@ export function useField(provided: ProvidedField): Field | null {
     $error,
     $choice,
     $setChoice,
+    autotrim,
   ])
   return $field
 }

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -8,6 +8,12 @@ import {
 import type { Dispatch, SetStateAction } from 'react'
 import { setStateOnChange } from 'utils/forms'
 
+export enum WHITESPACE {
+  DEFAULT = 'DEFAULT',
+  BANNED = 'BANNED',
+  TRIMMED = 'TRIMMED',
+}
+
 export interface NameValue {
   name: string
   value: string
@@ -22,7 +28,7 @@ export interface ProvidedField {
   isRadioed?: boolean
   options?: NameValue[]
   defaultErrorText?: string
-  autotrim?: boolean
+  whitespace?: WHITESPACE
 }
 export interface Field extends ProvidedField {
   value: string
@@ -50,7 +56,9 @@ export function useField(provided: ProvidedField): Field | null {
     provided.options &&
     provided.options[0] &&
     provided.options[0].value
-  const { autotrim = true } = provided
+  const { whitespace = WHITESPACE.DEFAULT } = provided
+  const banSpaces = whitespace === WHITESPACE.BANNED
+  const trimSpaces = banSpaces || whitespace === WHITESPACE.TRIMMED
   const [$choice, $setChoice] = useState<string>(
     provided.isRadioed && radioOption ? radioOption : ''
   )
@@ -70,7 +78,7 @@ export function useField(provided: ProvidedField): Field | null {
       defaultValue,
       value: $value,
       valid,
-      autotrim,
+      whitespace,
       setValid: $setValid,
       setter: $setter,
       onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
@@ -83,11 +91,11 @@ export function useField(provided: ProvidedField): Field | null {
           key: e.key,
           // selected,
         })
-        if (autotrim && e.key === ' ') {
+        if (banSpaces && e.key === ' ') {
           e.preventDefault()
         }
       },
-      onChange: setStateOnChange($setter, autotrim),
+      onChange: setStateOnChange($setter, trimSpaces),
       onBlur: () => {
         $setTouched(true)
       },
@@ -109,7 +117,9 @@ export function useField(provided: ProvidedField): Field | null {
     $error,
     $choice,
     $setChoice,
-    autotrim,
+    whitespace,
+    banSpaces,
+    trimSpaces,
   ])
   return $field
 }

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -69,7 +69,12 @@ export function useField(provided: ProvidedField): Field | null {
       setter: $setter,
       onKeyDown: e => {
         // eslint-disable-next-line
-        console.log({ event: e, key: e.key })
+        console.log({
+          // @ts-ignore
+          value: (e && e.target && e.target.value) || 'nothing set',
+          event: e,
+          key: e.key,
+        })
         if (autotrim && e.key === ' ') {
           e.preventDefault()
         }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -10,7 +10,7 @@ import { FieldError } from 'components/Form/FieldStatus'
 import Loader from 'components/Loader'
 import SignupCTA from 'components/login/SignupCTA'
 
-import { useField } from 'hooks/useForm'
+import { WHITESPACE, useField } from 'hooks/useForm'
 import { useQuery } from 'hooks/useQuery'
 
 import { useProtectedRoute, STATUS } from 'hooks/useProtectedRoute'
@@ -31,6 +31,7 @@ const FIELDS = {
     defaultValue: UNSET,
     validation: validateEmail,
     defaultErrorText: `Valid email address required`,
+    WHITESPACE: WHITESPACE.BANNED,
   },
 }
 export default function Login() {

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -10,7 +10,7 @@ import { FieldError } from 'components/Form/FieldStatus'
 import SignUpForm from 'components/signup/SignUpForm'
 import { CountryWithCode, countries } from 'data/countries'
 import { createUser } from 'apiClient'
-import { useField } from 'hooks/useForm'
+import { useField, WHITESPACE } from 'hooks/useForm'
 import { useProtectedRoute, STATUS } from 'hooks/useProtectedRoute'
 import { scrollUp } from 'utils/scroll'
 import {
@@ -32,6 +32,7 @@ export const FIELDS = {
     defaultValue: UNSET,
     validation: validateEmail,
     defaultErrorText: `Valid email address required`,
+    whitespace: WHITESPACE.BANNED,
   },
   graffiti: {
     id: 'graffiti',
@@ -40,6 +41,7 @@ export const FIELDS = {
     defaultValue: UNSET,
     validation: validateGraffiti,
     defaultErrorText: `Graffiti is too long`,
+    whitespace: WHITESPACE.TRIMMED,
   },
   social: {
     id: 'social',
@@ -49,6 +51,7 @@ export const FIELDS = {
     validation: exists,
     defaultErrorText,
     isRadioed: true,
+    whitespace: WHITESPACE.BANNED,
     options: [
       { name: 'Discord', value: 'discord' },
       { name: 'Telegram', value: 'telegram' },

--- a/utils/forms.ts
+++ b/utils/forms.ts
@@ -27,13 +27,13 @@ export const defaultErrorText = `This field is required`
 // take a setter and turn it into an event handler which sets
 export function setStateOnChange(
   setter: Dispatch<SetStateAction<string>>,
-  autotrim = false
+  trim = false
 ) {
   return (e: ChangeEvent) => {
     const raw = (e.target as HTMLInputElement).value
-    const toSet = autotrim ? raw.trim() : raw
+    const toSet = trim ? raw.trim() : raw
     // eslint-disable-next-line no-console
-    console.log({ autotrim, toSet })
+    console.log({ trim, toSet })
     setter(toSet)
   }
 }

--- a/utils/forms.ts
+++ b/utils/forms.ts
@@ -33,8 +33,6 @@ export function setStateOnChange(
   return (e: ChangeEvent) => {
     const raw = (e.target as HTMLInputElement).value
     const toSet = trim ? raw.trim() : raw
-    // eslint-disable-next-line no-console
-    console.log({ trim, toSet })
     setter(toSet)
   }
 }

--- a/utils/forms.ts
+++ b/utils/forms.ts
@@ -31,6 +31,9 @@ export function setStateOnChange(
 ) {
   return (e: ChangeEvent) => {
     const raw = (e.target as HTMLInputElement).value
-    setter(autotrim ? raw.trim() : raw)
+    const toSet = autotrim ? raw.trim() : raw
+    // eslint-disable-next-line no-console
+    console.log({ autotrim, toSet })
+    setter(toSet)
   }
 }

--- a/utils/forms.ts
+++ b/utils/forms.ts
@@ -25,8 +25,12 @@ export const exists = (x: string) => x.trim().length > 0
 export const defaultErrorText = `This field is required`
 
 // take a setter and turn it into an event handler which sets
-export function setStateOnChange(setter: Dispatch<SetStateAction<string>>) {
+export function setStateOnChange(
+  setter: Dispatch<SetStateAction<string>>,
+  autotrim = false
+) {
   return (e: ChangeEvent) => {
-    setter((e.target as HTMLInputElement).value)
+    const raw = (e.target as HTMLInputElement).value
+    setter(autotrim ? raw.trim() : raw)
   }
 }

--- a/utils/forms.ts
+++ b/utils/forms.ts
@@ -1,4 +1,5 @@
 import { ChangeEvent, Dispatch, SetStateAction } from 'react'
+export { WHITESPACE } from 'hooks/useForm'
 
 // naive validators
 


### PR DESCRIPTION
## Summary

- [x] Fixes IRO-1402 - Trim Graffiti on Registration

Now form fields can specify their `WHITESPACE` rules:

1. `WHITESPACE.DEFAULT` - This keeps the behavior of all extant things
2. `WHITESPACE.TRIMMED` - This implicitly trims (removes trailing + leading whitespace) strings, so if you write `     cooluser     ` (note the trailing spaces) the system only registers `cooluser` as the value.
3. `WHITESPACE.BANNED` - This prevents any whitespace from being entered on a given form.

## Testing Plan

1. Go to: [Sign Up](https://website-testnet-git-trim-yo-strings-ironfish.vercel.app/signup) (you may need to log out first)
2. Try entering spaces on the *Email* or *Social* (Discord / Telegram) fields, they will not be allowed.
3. Spaces can be entered on the *Graffiti* field, they will be allowed to be entered but the resulting value (which will be in the email you receive) won't have leading or trailing spaces, but will be allowed internal to the string boundaries. (e.g. `Blah Blah` is valid, but is the same as `       Blah Blah        `)

## Breaking Change

Is this a breaking change? Not to anything which hasn't changed its `whitespace` value.
