### PR TITLE
Support local editing with user fixture

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_API_URL=https://api.ironfish.network
 API_URL=https://api.ironfish.network
 NEXT_PUBLIC_MAGIC_PUBLISHABLE_KEY=test
+NEXT_PUBLIC_LOCAL_USER=true

--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -136,4 +136,39 @@ export function useLogin(config: LoginProps = {}) {
 
 export type LoginContext = ReturnType<typeof useLogin>
 
+export const useLocalLogin = () => ({
+  checkLoggedIn: () => true,
+  checkLoading: () => false,
+  checkFailed: () => false,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setError: () => {},
+  error: '',
+  status: STATUS.LOADED,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setStatus: () => {},
+  metadata: {
+    id: 111,
+    created_at: '2021-10-30T23:28:59.505Z',
+    updated_at: '2021-10-30T23:43:28.555Z',
+    email: 'cooldev@ironfish.network',
+    graffiti: 'cooldev',
+    total_points: 1100,
+    country_code: 'USA',
+    email_notifications: false,
+    last_login_at: '2021-10-30T23:29:49.101Z',
+    discord: 'coolcooldev',
+    telegram: '',
+    confirmation_token: '01FNSJW53E9J029SKXYA2020KN',
+    confirmed_at: '2021-10-30T23:43:28.554Z',
+    github: '',
+  },
+  magicMetadata: {
+    issuer: 'did:ethr:0xFfcD8602De681449Fa70C304096a84e014Fa123C',
+    publicAddress: '0xFfcD8602De681449Fa70C304096a84e014Fa123C',
+    email: 'cooldev@ironfish.network',
+    isMfaEnabled: false,
+    phoneNumber: null,
+  },
+})
+
 export default useLogin

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,10 +2,13 @@ import 'styles/globals.css'
 import Head from 'next/head'
 import type { AppProps } from 'next/app'
 import ResponsiveToolkit from 'components/ResponsiveToolkit'
-import { useLogin } from 'hooks/useLogin'
+import { useLogin, useLocalLogin } from 'hooks/useLogin'
+
+const LOCAL_MODE = process.env.NEXT_PUBLIC_LOCAL_USER || false
+const loginHook = LOCAL_MODE ? useLocalLogin : useLogin
 
 function MyApp({ Component: Page, pageProps }: AppProps) {
-  const $login = useLogin()
+  const $login = loginHook()
   const { metadata } = $login
   return (
     <>


### PR DESCRIPTION
## Summary

We've made the decision (see previous [Login PR](https://github.com/iron-fish/website-testnet/pull/126#discussion_r764183123)) to make some of our UI hang in a loading state until it hears back from Magic Link. This is good in non-local environments, but locally it's a bit of a PITA to use things.

## Testing Plan

Make sure this doesn't change anything except locally.

## Breaking Change

No, unless you set `NEXT_PUBLIC_LOCAL_USER` to true in production.