### PR TITLE
Remove gitparty from package-scripts

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -24,7 +24,6 @@ module.exports = {
     care: concurrent.nps('build', 'lint'),
     dx: concurrent.nps('build', 'lint', 'meta.dependencies'),
     meta: {
-      log: `gitparty`,
       dependencies: {
         build: `depcruise -c .dependency-cruiser.js -T dot components pages apiClient contexts data definitions hooks public styles utils --progress -x node_modules definitions | dot -T svg > dependency-graph.svg`,
         interactive: `cat dependency-graph.svg | depcruise-wrap-stream-in-html > dependency-graph.html`,


### PR DESCRIPTION
## Summary

gitparty was removed in #155, so this script shouldn't be needed now either.

## Testing Plan

None needed.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
