### PR TITLE
Type useLocalLogin

### DIFF
--- a/hooks/useLocalLogin.ts
+++ b/hooks/useLocalLogin.ts
@@ -1,0 +1,32 @@
+import { LoginContext, STATUS } from './useLogin'
+
+export const useLocalLogin = (): LoginContext => ({
+  checkLoggedIn: () => true,
+  checkLoading: () => false,
+  checkFailed: () => false,
+  setError: () => {},
+  error: null,
+  status: STATUS.LOADED,
+  setStatus: () => {},
+  metadata: {
+    id: 111,
+    created_at: '2021-10-30T23:28:59.505Z',
+    updated_at: '2021-10-30T23:43:28.555Z',
+    email: 'cooldev@ironfish.network',
+    graffiti: 'cooldev',
+    total_points: 1100,
+    country_code: 'USA',
+    email_notifications: false,
+    last_login_at: '2021-10-30T23:29:49.101Z',
+    discord: 'coolcooldev',
+    telegram: '',
+  },
+  magicMetadata: {
+    issuer: 'did:ethr:0xFfcD8602De681449Fa70C304096a84e014Fa123C',
+    publicAddress: '0xFfcD8602De681449Fa70C304096a84e014Fa123C',
+    email: 'cooldev@ironfish.network',
+    phoneNumber: null,
+  },
+})
+
+export default useLocalLogin

--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -136,39 +136,4 @@ export function useLogin(config: LoginProps = {}) {
 
 export type LoginContext = ReturnType<typeof useLogin>
 
-export const useLocalLogin = () => ({
-  checkLoggedIn: () => true,
-  checkLoading: () => false,
-  checkFailed: () => false,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  setError: () => {},
-  error: '',
-  status: STATUS.LOADED,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  setStatus: () => {},
-  metadata: {
-    id: 111,
-    created_at: '2021-10-30T23:28:59.505Z',
-    updated_at: '2021-10-30T23:43:28.555Z',
-    email: 'cooldev@ironfish.network',
-    graffiti: 'cooldev',
-    total_points: 1100,
-    country_code: 'USA',
-    email_notifications: false,
-    last_login_at: '2021-10-30T23:29:49.101Z',
-    discord: 'coolcooldev',
-    telegram: '',
-    confirmation_token: '01FNSJW53E9J029SKXYA2020KN',
-    confirmed_at: '2021-10-30T23:43:28.554Z',
-    github: '',
-  },
-  magicMetadata: {
-    issuer: 'did:ethr:0xFfcD8602De681449Fa70C304096a84e014Fa123C',
-    publicAddress: '0xFfcD8602De681449Fa70C304096a84e014Fa123C',
-    email: 'cooldev@ironfish.network',
-    isMfaEnabled: false,
-    phoneNumber: null,
-  },
-})
-
 export default useLogin

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,8 @@ import 'styles/globals.css'
 import Head from 'next/head'
 import type { AppProps } from 'next/app'
 import ResponsiveToolkit from 'components/ResponsiveToolkit'
-import { useLogin, useLocalLogin } from 'hooks/useLogin'
+import { useLogin } from 'hooks/useLogin'
+import { useLocalLogin } from 'hooks/useLocalLogin'
 
 const LOCAL_MODE = process.env.NEXT_PUBLIC_LOCAL_USER || false
 const loginHook = LOCAL_MODE ? useLocalLogin : useLogin


### PR DESCRIPTION
## Summary

useLocalLogin returned an inconsitent return type from useLogin. This
fixes that, and moves it into its own file so we have 1 hook per file as
the code base seems to use.

## Testing Plan
Ran code with both hooks

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
