### PR TITLE
Increase weekly PR points to 5000

### DIFF
--- a/components/About/data.tsx
+++ b/components/About/data.tsx
@@ -139,6 +139,7 @@ export const callsToAction = {
       title: 'Submit a Pull Request',
       content:
         'Submit a PR to the Iron Fish repo. Points are earned if the PR gets accepted and merged. Fill out the form to claim your points after your PR is merged.',
+      earn: 5000,
       points: [
         'Small PR = 250 points',
         'Medium PR = 750 points',

--- a/components/user/Tabs/WeeklyContent.tsx
+++ b/components/user/Tabs/WeeklyContent.tsx
@@ -8,18 +8,6 @@ type WeeklyContentProps = {
   metricsConfig: API.MetricsConfigResponse
 }
 
-// Given a metrics config response, computes the maximum number of
-// events for a given metric that can be scored per-week.
-function getWeeklyMetricMax(
-  key: API.EventType,
-  metricsConfig: API.MetricsConfigResponse
-) {
-  return (
-    metricsConfig.weekly_limits[key] /
-    metricsConfig.points_per_category.BLOCK_MINED
-  )
-}
-
 export default function WeeklyContent({
   weeklyMetrics,
   metricsConfig,
@@ -29,42 +17,38 @@ export default function WeeklyContent({
       <WeeklyMetricCard
         title="Blocks Mined"
         metric={weeklyMetrics.metrics.blocks_mined}
-        metricValueMax={getWeeklyMetricMax(
-          API.EventType.BLOCK_MINED,
-          metricsConfig
-        )}
+        metricValueMax={metricsConfig.weekly_limits[API.EventType.BLOCK_MINED]}
+        unit="blocks"
       />
       <WeeklyMetricCard
         title="Bugs Caught"
         metric={weeklyMetrics.metrics.bugs_caught}
-        metricValueMax={getWeeklyMetricMax(
-          API.EventType.BUG_CAUGHT,
-          metricsConfig
-        )}
+        metricValueMax={metricsConfig.weekly_limits[API.EventType.BUG_CAUGHT]}
+        unit="bugs"
       />
       <WeeklyMetricCard
         title="Promotions"
         metric={weeklyMetrics.metrics.social_media_contributions}
-        metricValueMax={getWeeklyMetricMax(
-          API.EventType.SOCIAL_MEDIA_PROMOTION,
-          metricsConfig
-        )}
+        metricValueMax={
+          metricsConfig.weekly_limits[API.EventType.SOCIAL_MEDIA_PROMOTION]
+        }
+        unit="promotions"
       />
       <WeeklyMetricCard
         title="PRs Merged"
         metric={weeklyMetrics.metrics.pull_requests_merged}
-        metricValueMax={getWeeklyMetricMax(
-          API.EventType.PULL_REQUEST_MERGED,
-          metricsConfig
-        )}
+        metricValueMax={
+          metricsConfig.weekly_limits[API.EventType.PULL_REQUEST_MERGED]
+        }
+        unit="PRs"
       />
       <WeeklyMetricCard
         title="Community Contributions"
         metric={weeklyMetrics.metrics.community_contributions}
-        metricValueMax={getWeeklyMetricMax(
-          API.EventType.COMMUNITY_CONTRIBUTION,
-          metricsConfig
-        )}
+        metricValueMax={
+          metricsConfig.weekly_limits[API.EventType.COMMUNITY_CONTRIBUTION]
+        }
+        unit="contributions"
       />
     </div>
   )

--- a/components/user/Tabs/WeeklyContent.tsx
+++ b/components/user/Tabs/WeeklyContent.tsx
@@ -12,42 +12,44 @@ export default function WeeklyContent({
   weeklyMetrics,
   metricsConfig,
 }: WeeklyContentProps) {
+  const {
+    [API.EventType.BLOCK_MINED]: blockMinedLimit,
+    [API.EventType.BUG_CAUGHT]: bugsCaughtWeeklyLimit,
+    [API.EventType.SOCIAL_MEDIA_PROMOTION]: promotionLimit,
+    [API.EventType.PULL_REQUEST_MERGED]: prLimit,
+    [API.EventType.COMMUNITY_CONTRIBUTION]: contributionLimit,
+  } = metricsConfig.weekly_limits
+
   return (
     <div className="flex gap-3 mt-4 mb-12 flex-wrap">
       <WeeklyMetricCard
         title="Blocks Mined"
         metric={weeklyMetrics.metrics.blocks_mined}
-        metricValueMax={metricsConfig.weekly_limits[API.EventType.BLOCK_MINED]}
+        metricValueMax={blockMinedLimit}
         unit="blocks"
       />
       <WeeklyMetricCard
         title="Bugs Caught"
         metric={weeklyMetrics.metrics.bugs_caught}
-        metricValueMax={metricsConfig.weekly_limits[API.EventType.BUG_CAUGHT]}
+        metricValueMax={bugsCaughtWeeklyLimit}
         unit="bugs"
       />
       <WeeklyMetricCard
         title="Promotions"
         metric={weeklyMetrics.metrics.social_media_contributions}
-        metricValueMax={
-          metricsConfig.weekly_limits[API.EventType.SOCIAL_MEDIA_PROMOTION]
-        }
+        metricValueMax={promotionLimit}
         unit="promotions"
       />
       <WeeklyMetricCard
         title="PRs Merged"
         metric={weeklyMetrics.metrics.pull_requests_merged}
-        metricValueMax={
-          metricsConfig.weekly_limits[API.EventType.PULL_REQUEST_MERGED]
-        }
+        metricValueMax={prLimit}
         unit="PRs"
       />
       <WeeklyMetricCard
         title="Community Contributions"
         metric={weeklyMetrics.metrics.community_contributions}
-        metricValueMax={
-          metricsConfig.weekly_limits[API.EventType.COMMUNITY_CONTRIBUTION]
-        }
+        metricValueMax={contributionLimit}
         unit="contributions"
       />
     </div>

--- a/components/user/Tabs/WeeklyMetricCard.tsx
+++ b/components/user/Tabs/WeeklyMetricCard.tsx
@@ -7,19 +7,21 @@ type WeeklyMetricCardProps = {
   title: string
   metric: API.UserMetric
   metricValueMax: number
+  unit: string
 }
 
 export default function WeeklyMetricCard({
   title,
   metric,
   metricValueMax,
+  unit,
 }: WeeklyMetricCardProps) {
   return (
     <MetricCard
       title={title}
-      value={metric.count.toLocaleString()}
+      value={metric.points.toLocaleString()}
       subValueTop={`/ ${metricValueMax.toLocaleString()}`}
-      subValueBottom={`${metric.points.toLocaleString()} points`}
+      subValueBottom={`${metric.count.toLocaleString()} ${unit}`}
     />
   )
 }


### PR DESCRIPTION
## Summary

Updating the "Earn up to 5000 points per week" on the About page was pretty straightforward. For the weekly stats page, since PRs can be awarded variable amounts of points, it doesn't exactly work to show the maximum number of PRs that can be submitted per week -- I changed it to instead show the points as the major value, and the point value max. Then underneath, it shows the instances of each event (i.e. number of blocks mined, number of PRs submitted)

![image](https://user-images.githubusercontent.com/767083/149436359-c45ef50a-9ac7-4617-9e05-b75e6171f4ad.png)


## Testing Plan

Load up some users and check that their pages display correctly. You can include more data into the data that's shown in the current week on staging by editing the `getWeeklyStart` function locally.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
