### PR TITLE
Fixed claim points buttons linking to the wrong place

### DIFF
--- a/components/About/CallToAction.tsx
+++ b/components/About/CallToAction.tsx
@@ -77,7 +77,9 @@ export const CallToAction = ({
                 className="m-auto w-full mt-2 max-w-md mb-2 text-md p-2"
                 colorClassName="text-black bg-transparent hover:bg-black hover:text-white"
               >
-                {href ? <Link href={href}>Claim Points</Link> : ctaText}
+                <Link href={'https://forms.gle/yrAtzoyKTwLgLTRZA'}>
+                  Claim Points
+                </Link>
               </RawButton>
             </Link>
           )}

--- a/cypress/integration/pages/about.ts
+++ b/cypress/integration/pages/about.ts
@@ -50,7 +50,7 @@ describe('/about', () => {
       {
         isImage: false,
         text: 'Claim Points',
-        href: 'https://github.com/iron-fish/ironfish/issues',
+        href: 'https://forms.gle/yrAtzoyKTwLgLTRZA',
       },
       {
         isImage: false,
@@ -75,7 +75,7 @@ describe('/about', () => {
       {
         isImage: false,
         text: 'Claim Points',
-        href: 'https://github.com/iron-fish/ironfish/pulls',
+        href: 'https://forms.gle/yrAtzoyKTwLgLTRZA',
       },
       {
         isImage: false,


### PR DESCRIPTION
## Summary
The link buttons weren't going to the right place, they were linking to the HREF of the call to action and not the claim page.

https://website-testnet-git-fix-links-ironfish.vercel.app/about

## Testing Plan

Tested manually and updated broken tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
