### PR TITLE
Fixing margins for testnet about sections

### DIFF
--- a/components/About/CallToAction.tsx
+++ b/components/About/CallToAction.tsx
@@ -6,7 +6,7 @@ import { RawButton } from 'components/Button'
 
 type CTAProps = {
   title: string
-  content?: string
+  content?: ReactNode
   children?: ReactNode
   kind?: string
   earn?: number
@@ -31,7 +31,7 @@ export const CallToAction = ({
   const button = ctaText ? (
     <RawButton
       border="border"
-      className="m-auto w-full mt-8 max-w-md mb-2 text-md p-2"
+      className="m-auto w-full max-w-md mb-2 text-md p-2"
       colorClassName="text-black bg-transparent hover:bg-black hover:text-white"
     >
       {href ? <Link href={href}>{ctaText}</Link> : ctaText}
@@ -65,6 +65,7 @@ export const CallToAction = ({
               Earn up to {earn.toLocaleString('en-US')} points a week
             </div>
           )}
+          <div className="mb-8" />
           {ctaText && href && button ? (
             <Link href={href}>{button}</Link>
           ) : (


### PR DESCRIPTION
## Summary
Before: 
<img width="553" alt="Screen Shot 2022-02-08 at 2 11 36 PM" src="https://user-images.githubusercontent.com/2285160/153084335-bfba99c6-0b56-444d-b59e-f6718281a0f4.png">
After:
<img width="588" alt="Screen Shot 2022-02-08 at 2 11 21 PM" src="https://user-images.githubusercontent.com/2285160/153084350-2b6069f0-fbcf-4cfe-a5f0-45f2691b1e6d.png">


## Testing Plan
Tested locally. Looks 👌

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] No
[ ] Yes
```
