### PR TITLE
IRO-1541 - Render events whose occurred_at value is before Testnet started

### DIFF
--- a/components/leaderboard/CountdownTimer.tsx
+++ b/components/leaderboard/CountdownTimer.tsx
@@ -3,7 +3,8 @@ import { CustomBox } from 'components/OffsetBorder'
 import { intervalToDuration } from 'date-fns'
 import type { Duration } from 'date-fns'
 
-import { formatEventDate, nextMondayFrom } from 'utils/date'
+import { nextMondayFrom } from 'utils/date'
+import { formatEventDate } from 'utils/events'
 
 const customFormatDuration = (x: Duration) =>
   `${x.days ? x.days + 'd : ' : ''}${x.hours ? x.hours + 'hr : ' : ''}${

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,14 +1,5 @@
-import {
-  set,
-  nextMonday,
-  isBefore,
-  isAfter,
-  eachWeekOfInterval,
-  addMinutes,
-} from 'date-fns'
-import { toDate, format, utcToZonedTime } from 'date-fns-tz'
-
-import { ApiEvent } from 'apiClient'
+import { set, nextMonday, eachWeekOfInterval, addMinutes } from 'date-fns'
+import { format, utcToZonedTime } from 'date-fns-tz'
 
 // modified version of https://github.com/date-fns/date-fns/issues/1401#issuecomment-621897094
 export const makeRelativeConverter = () => {
@@ -24,23 +15,10 @@ export const weeksBetween = (start: Date, end: Date) => {
   return raw.map(convert)
 }
 
-export const withinBounds = (start: Date, end: Date) => (e: ApiEvent) => {
-  const time = toDate(e.occurred_at)
-  return isAfter(time, start) && isBefore(time, end)
-}
-
-export const eventsBetween = (
-  start: Date,
-  end: Date,
-  events: ApiEvent[]
-): ApiEvent[] => events.filter(withinBounds(start, end))
-
 export const formatInTimeZone =
   (timeZone: string) => (date: Date, formatString: string) =>
     format(utcToZonedTime(date, timeZone), formatString, { timeZone })
 export const formatUTC = formatInTimeZone('UTC')
-export const formatEventDate = (d: Date) =>
-  formatUTC(d, `y'-'MM'-'dd HH':'mm':'ss`)
 
 export const nextMondayFrom = (when: Date) => {
   const convert = makeRelativeConverter()

--- a/utils/events.ts
+++ b/utils/events.ts
@@ -20,31 +20,25 @@ export const eventsBetween = (
   events: ApiEvent[]
 ): ApiEvent[] => events.filter(withinBounds(start, end))
 
-export function uniqueById(x: readonly ApiEvent[]) {
-  return x.reduce((agg: ApiEvent[], i: ApiEvent) => {
-    if (!agg.map(({ id }) => id).includes(i.id)) {
-      return agg.concat(i)
-    }
-    return agg
-  }, [])
+export const getAllVisibleEvents = (weeklyData: WeeklyData[]) => {
+  const m = new Map()
+  const allEvents = weeklyData.flatMap(({ events }) => events)
+  allEvents.forEach(e => m.set(e.id, e))
+  return m
 }
-
-export const getAllVisibleEvents = (weeklyData: WeeklyData[]) =>
-  weeklyData.reduce((agg: ApiEvent[], { events }) => {
-    return agg.concat(events)
-  }, [])
 
 export const findMissingEvents = (
   allEvents: readonly ApiEvent[],
   weeklyData: WeeklyData[]
-) =>
-  allEvents.reduce((agg: ApiEvent[], x: ApiEvent) => {
-    const onlyMatched = getAllVisibleEvents(weeklyData)
-    if (onlyMatched.map(({ id }: { id: number }) => id).includes(x.id)) {
+) => {
+  const onlyMatched = getAllVisibleEvents(weeklyData)
+  return allEvents.reduce((agg: ApiEvent[], x: ApiEvent) => {
+    if (onlyMatched.has(x.id)) {
       return agg
     }
     return agg.concat(x)
   }, [])
+}
 
 const sortEventsByDate = (xs: ApiEvent[]) =>
   xs.sort((a: ApiEvent, b: ApiEvent): number =>

--- a/utils/events.ts
+++ b/utils/events.ts
@@ -98,7 +98,7 @@ export const bucketEventsAndAccountForMissingOnes = (
   const weeklyData = bucketEvents(start, end, rawEvents)
   const missingEvents = findMissingEvents(rawEvents, weeklyData)
   const eventsPriorToStart = missingEvents.filter(({ occurred_at: time }) =>
-    isBefore(start, toDate(time))
+    isBefore(toDate(time), start)
   )
   if (eventsPriorToStart.length > 0) {
     return weeklyData.concat({

--- a/utils/events.ts
+++ b/utils/events.ts
@@ -46,18 +46,6 @@ export const findMissingEvents = (
     return agg.concat(x)
   }, [])
 
-/*
-const retest = (allEvents: ApiEvent[], weeklyData: WeeklyData[]) =>
-  weeklyData.reduce(
-    (agg: ApiEvent[], { prior: a, date: z }: { prior: Date; date: Date }) => {
-      const missing = findMissingEvents(allEvents, weeklyData)
-      return agg.concat(
-        missing.filter((ev: ApiEvent) => withinBounds(a, z)(ev))
-      )
-    },
-    []
-  )
-*/
 const sortEventsByDate = (xs: ApiEvent[]) =>
   xs.sort((a: ApiEvent, b: ApiEvent): number =>
     a.occurred_at > b.occurred_at ? -1 : 1

--- a/utils/events.ts
+++ b/utils/events.ts
@@ -1,0 +1,115 @@
+import { isBefore, isAfter } from 'date-fns'
+import { toDate } from 'date-fns-tz'
+import { formatUTC, weeksBetween } from './date'
+import { ApiEvent } from 'apiClient'
+
+export type WeeklyData = {
+  week: number
+  date: Date
+  prior: Date
+  events: ApiEvent[]
+}
+
+export const withinBounds = (start: Date, end: Date) => (e: ApiEvent) => {
+  const time = toDate(e.occurred_at)
+  return isAfter(time, start) && isBefore(time, end)
+}
+export const eventsBetween = (
+  start: Date,
+  end: Date,
+  events: ApiEvent[]
+): ApiEvent[] => events.filter(withinBounds(start, end))
+
+export function uniqueById(x: readonly ApiEvent[]) {
+  return x.reduce((agg: ApiEvent[], i: ApiEvent) => {
+    if (!agg.map(({ id }) => id).includes(i.id)) {
+      return agg.concat(i)
+    }
+    return agg
+  }, [])
+}
+
+export const getAllVisibleEvents = (weeklyData: WeeklyData[]) =>
+  weeklyData.reduce((agg: ApiEvent[], { events }) => {
+    return agg.concat(events)
+  }, [])
+
+export const findMissingEvents = (
+  allEvents: readonly ApiEvent[],
+  weeklyData: WeeklyData[]
+) =>
+  allEvents.reduce((agg: ApiEvent[], x: ApiEvent) => {
+    const onlyMatched = getAllVisibleEvents(weeklyData)
+    if (onlyMatched.map(({ id }: { id: number }) => id).includes(x.id)) {
+      return agg
+    }
+    return agg.concat(x)
+  }, [])
+
+/*
+const retest = (allEvents: ApiEvent[], weeklyData: WeeklyData[]) =>
+  weeklyData.reduce(
+    (agg: ApiEvent[], { prior: a, date: z }: { prior: Date; date: Date }) => {
+      const missing = findMissingEvents(allEvents, weeklyData)
+      return agg.concat(
+        missing.filter((ev: ApiEvent) => withinBounds(a, z)(ev))
+      )
+    },
+    []
+  )
+*/
+const sortEventsByDate = (xs: ApiEvent[]) =>
+  xs.sort((a: ApiEvent, b: ApiEvent): number =>
+    a.occurred_at > b.occurred_at ? -1 : 1
+  )
+const makeCounter = () => {
+  let x = 0
+  return () => x++
+}
+export const bucketEvents = (
+  start: Date,
+  end: Date,
+  rawEvents: readonly ApiEvent[]
+): WeeklyData[] => {
+  const weeks = weeksBetween(start, end)
+  const counter = makeCounter()
+  return weeks
+    .reduce((agg: WeeklyData[], date: Date) => {
+      const prev = agg[agg.length - 1]
+      const prior = prev ? prev.date : start
+      const events = sortEventsByDate(
+        eventsBetween(prior, date, rawEvents as ApiEvent[])
+      )
+      return agg.concat({
+        prior,
+        date,
+        events,
+        week: counter(),
+      })
+    }, [])
+    .reverse()
+}
+
+export const bucketEventsAndAccountForMissingOnes = (
+  start: Date,
+  end: Date,
+  rawEvents: readonly ApiEvent[]
+) => {
+  const weeklyData = bucketEvents(start, end, rawEvents)
+  const missingEvents = findMissingEvents(rawEvents, weeklyData)
+  const eventsPriorToStart = missingEvents.filter(({ occurred_at: time }) =>
+    isBefore(start, toDate(time))
+  )
+  if (eventsPriorToStart.length > 0) {
+    return weeklyData.concat({
+      prior: new Date(2020, 1, 1),
+      date: start,
+      events: eventsPriorToStart,
+      week: -1,
+    })
+  }
+  return weeklyData
+}
+
+export const formatEventDate = (d: Date) =>
+  formatUTC(d, `y'-'MM'-'dd HH':'mm':'ss`)


### PR DESCRIPTION
## Summary

Events from before the testnet are valid and should be rendered.

Now they are.

## Testing Plan

1. Add events to a user before Dec. 1, 2021
2. They will render like this: ![CleanShot 2022-02-11 at 09 36 11](https://user-images.githubusercontent.com/18919/153640856-b9c0b882-68f6-4112-b563-7e6e3ffa2e1e.png)
3. Profit ?

## Breaking Change

Nope.