### PR TITLE
Fix E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ jobs:
       preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
       - name: Wait for Vercel preview deployment to be ready
-        uses: patrickedqvist/wait-for-vercel-preview@master
+        uses: patrickedqvist/wait-for-vercel-preview@v1.2.0
         id: waitForVercelPreviewDeployment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/cypress/integration/pages/about.ts
+++ b/cypress/integration/pages/about.ts
@@ -59,6 +59,11 @@ describe('/about', () => {
       },
       {
         isImage: false,
+        text: 'Claim Points',
+        href: 'https://forms.gle/yrAtzoyKTwLgLTRZA',
+      },
+      {
+        isImage: false,
         text: 'Email us',
         href: 'mailto:testnet@ironfish.network',
       },
@@ -71,6 +76,11 @@ describe('/about', () => {
         isImage: false,
         text: 'Get started with mining',
         href: 'https://ironfish.network/docs/onboarding/miner-iron-fish',
+      },
+      {
+        isImage: false,
+        text: 'examples.',
+        href: 'https://coda.io/d/_dVdKS2S-D2Q/How-points-for-non-mining-activity-are-awarded-Community-Contrib_su51s',
       },
       {
         isImage: false,

--- a/cypress/integration/pages/about.ts
+++ b/cypress/integration/pages/about.ts
@@ -54,8 +54,8 @@ describe('/about', () => {
       },
       {
         isImage: false,
-        text: 'Claim Points',
-        href: 'https://forms.gle/yrAtzoyKTwLgLTRZA',
+        text: 'examples.',
+        href: 'https://coda.io/d/_dVdKS2S-D2Q/How-points-for-non-mining-activity-are-awarded-Community-Contrib_su51s',
       },
       {
         isImage: false,


### PR DESCRIPTION
## Summary

Integration tests stopped working, because in part:
1. We used to rely upon `patrickedqvist/wait-for-vercel-preview@master`, but now we evidently have to use: `patrickedqvist/wait-for-vercel-preview@v1.2.0`
2. Because the tests were broken, the integration test snapshots had to be updated.

## Testing Plan

Check the automated tests.

## Breaking Change

Nope