### PR TITLE
fix leaderboard page on mobile

### DIFF
--- a/components/Form/Select.module.css
+++ b/components/Form/Select.module.css
@@ -1,6 +1,7 @@
 .customSelectWrapper {
   width: 100%;
   position: relative;
+  padding-right: 1rem;
 }
 .customSelect {
   appearance: none;
@@ -12,7 +13,7 @@
   position: absolute;
   right: 0;
   width: 1rem;
-  height: 2rem;
+  height: 1.5rem;
   text-align: center;
   background-image: url(/arrow_drop_down_black.png);
   background-repeat: no-repeat;

--- a/components/leaderboard/LeaderboardRow.tsx
+++ b/components/leaderboard/LeaderboardRow.tsx
@@ -20,7 +20,7 @@ function LeaderboardRow({ rank, graffiti, points = 0 }: Props) {
       style={{ boxShadow: '0 4px 4px 0 rgba(0, 0, 0, 0.19)' }}
     >
       <div className="absolute inset-0 rounded border hover:border-2 border-black" />
-      <div className="font-extended text-2xl w-24">{rankStr}</div>
+      <div className="font-extended text-2xl w-16 sm:w-24">{rankStr}</div>
       <div className="flex flex-1 items-center font-extended text-2xl overflow-hidden">
         <div className="py-3 mr-5">
           <FishAvatar color={avatarColor} />

--- a/components/leaderboard/LeaderboardRow.tsx
+++ b/components/leaderboard/LeaderboardRow.tsx
@@ -16,18 +16,18 @@ function LeaderboardRow({ rank, graffiti, points = 0 }: Props) {
 
   return (
     <div
-      className="relative bg-white rounded flex items-center px-10"
+      className="relative bg-white rounded flex items-center px-4 sm:px-10"
       style={{ boxShadow: '0 4px 4px 0 rgba(0, 0, 0, 0.19)' }}
     >
       <div className="absolute inset-0 rounded border hover:border-2 border-black" />
       <div className="font-extended text-2xl w-24">{rankStr}</div>
-      <div className="flex flex-1 items-center font-extended text-2xl">
+      <div className="flex flex-1 items-center font-extended text-2xl overflow-hidden">
         <div className="py-3 mr-5">
           <FishAvatar color={avatarColor} />
         </div>
-        <div>{graffiti}</div>
+        <div className="truncate">{graffiti}</div>
       </div>
-      <div className="font-extended text-2xl">{pointsStr}</div>
+      <div className="font-extended text-2xl ml-2">{pointsStr}</div>
     </div>
   )
 }

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -181,12 +181,12 @@ export default function Leaderboard({ loginContext }: Props) {
               </label>
             </div>
           </div>
-          <div className="font-extended flex px-10 mb-4">
+          <div className="font-extended flex px-4 sm:px-10 mb-4">
             {$users.length > 0 && (
               <>
                 <div className="w-24">RANK</div>
                 <div className="flex-1">USERNAME</div>
-                <div>TOTAL POINTS</div>
+                <div className="ml-2">TOTAL POINTS</div>
               </>
             )}
           </div>

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -184,7 +184,7 @@ export default function Leaderboard({ loginContext }: Props) {
           <div className="font-extended flex px-4 sm:px-10 mb-4">
             {$users.length > 0 && (
               <>
-                <div className="w-24">RANK</div>
+                <div className="w-16 sm:w-24">RANK</div>
                 <div className="flex-1">USERNAME</div>
                 <div className="ml-2">TOTAL POINTS</div>
               </>


### PR DESCRIPTION
## Summary
Fixing up issue referenced at https://github.com/iron-fish/website-testnet/issues/184. Changes made in this PR
- add extra padding in `<Select>` so text doesn't overlap with arrow on mobile
- `<Select>` arrow height was a bit off
- Leaderboard looks much better on mobile now

before:
<img width="466" alt="Screen Shot 2022-02-16 at 4 02 01 PM" src="https://user-images.githubusercontent.com/2752586/154306825-a582b94a-2466-4ac9-bc73-c0263b9147f8.png">

after:
<img width="458" alt="Screen Shot 2022-02-16 at 4 02 06 PM" src="https://user-images.githubusercontent.com/2752586/154306820-ca5a3251-4c62-45c3-9ecd-3e123200a469.png">

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
