### PR TITLE
Make leaderboard search full width

### DIFF
--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -156,7 +156,7 @@ export default function Leaderboard({ loginContext }: Props) {
                 <Search />
               </div>
               <input
-                className="text-lg pl-2 md:pl-5 h-full font-favorit bg-transparent placeholder-black focus:outline-none"
+                className="text-lg pl-2 md:pl-5 h-full w-full font-favorit bg-transparent placeholder-black focus:outline-none"
                 placeholder="Search"
                 onChange={e => {
                   $setSearch(e.target.value)


### PR DESCRIPTION
## Summary

I kept clicking in the invisible region and I couldn't find where the
bounds of the search were. This fixes that issue so it makes it so you
can click anywhere in the box.

![fulll-width-search](https://user-images.githubusercontent.com/458976/154340914-6cd23621-6d6f-4e4f-8181-926c91caa84d.gif)

## Testing Plan
Clicked around, recorded gif.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```

