### PR TITLE
Changing Community Contributions string to just Community

### DIFF
--- a/components/user/Tabs/AllTimeContent.tsx
+++ b/components/user/Tabs/AllTimeContent.tsx
@@ -29,7 +29,7 @@ export default function AllTimeContent({
         metric={allTimeMetrics.metrics.pull_requests_merged}
       />
       <AllTimeMetricCard
-        title="Community Contributions"
+        title="Community"
         metric={allTimeMetrics.metrics.community_contributions}
       />
     </div>

--- a/components/user/Tabs/WeeklyContent.tsx
+++ b/components/user/Tabs/WeeklyContent.tsx
@@ -47,7 +47,7 @@ export default function WeeklyContent({
         unit="PRs"
       />
       <WeeklyMetricCard
-        title="Community Contributions"
+        title="Community"
         metric={weeklyMetrics.metrics.community_contributions}
         metricValueMax={contributionLimit}
         unit="contributions"


### PR DESCRIPTION
## Summary
Just changing "Community Contributions" string to "Community" in the weekly/global view 

## Testing Plan
Local

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] No
[ ] Yes
```
