### PR TITLE
Fix login button & add `/me`

### DIFF
--- a/components/Navbar/LoginButton.tsx
+++ b/components/Navbar/LoginButton.tsx
@@ -103,7 +103,7 @@ const UserButton = ({ id, graffiti, visible }: ApiUserMetadataUI) => (
           'md:relative'
         )}
       >
-        <Link href={`/users/${id}`} passHref>
+        <Link href={`/me`} passHref>
           <div className={clsx('truncate', 'relative', 'max-w-[20rem]')}>
             {graffiti}
           </div>

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -9,6 +9,8 @@ const NOT_YET_SET = '-1'
 export function Me({ loginContext }: Props) {
   const $router = useRouter()
   const { checkLoggedIn, checkLoading } = loginContext
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(loginContext, null, 2))
   const [$id, $setId] = useState(NOT_YET_SET)
   useEffect(() => {
     if (!$router.isReady) return

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -1,0 +1,7 @@
+import { Props, User } from './users/[id]'
+
+export function Me({ loginContext }: Props) {
+  return <User loginContext={loginContext} startTab="settings" />
+}
+
+export default Me

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -27,6 +27,7 @@ export function Me({ loginContext }: Props) {
             // eslint-disable-next-line no-console
             console.log('I AM LOGGED IN', id)
             $setId(id.toString())
+            clearInterval(checkId)
           } else {
             // eslint-disable-next-line no-console
             console.log('I AM NOT LOGGED IN')

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -13,8 +13,20 @@ export function Me({ loginContext }: Props) {
   console.log(JSON.stringify(loginContext, null, 2))
   const [$id, $setId] = useState(NOT_YET_SET)
   useEffect(() => {
+    let count = 0
+    // eslint-disable-next-line
+    let checkId: NodeJS.Timeout
     if (!$router.isReady) return
     const check = () => {
+      if (count >= 10) {
+        clearInterval(checkId)
+        $router.push(
+          `/login?toast=${btoa('You must be logged in to see that page.')}`
+        )
+        return
+      } else {
+        count += 1
+      }
       const loggedIn = checkLoggedIn()
       const loading = checkLoading()
       const failed = checkFailed()
@@ -38,7 +50,7 @@ export function Me({ loginContext }: Props) {
         }
       }
     }
-    const checkId = setInterval(check, 100)
+    checkId = setInterval(check, 100)
     return () => clearInterval(checkId)
   }, [
     $router,

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -20,6 +20,11 @@ export function Me({ loginContext }: Props) {
       $setId(id.toString())
     }
   }, [$router, $router?.isReady, loginContext?.metadata?.id])
+  // eslint-disable-next-line no-console
+  console.log({
+    loginContext,
+    $id,
+  })
   return $id === NOT_YET_SET ? (
     <Loader />
   ) : (

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -1,7 +1,16 @@
+import { useRouter } from 'next/router'
 import { Props, User } from './users/[id]'
+import { encode as btoa } from 'base-64'
 
 export function Me({ loginContext }: Props) {
-  return <User loginContext={loginContext} startTab="settings" />
+  const $router = useRouter()
+  if (loginContext?.metadata?.id) {
+    return <User loginContext={loginContext} startTab="settings" />
+  } else {
+    return $router.push(
+      `/login?toast=${btoa('You must be logged in to see that page.')}`
+    )
+  }
 }
 
 export default Me

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -1,16 +1,30 @@
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
-import { Props, User } from './users/[id]'
 import { encode as btoa } from 'base-64'
+import Loader from 'components/Loader'
+
+import { Props, User } from './users/[id]'
+const NOT_YET_SET = '-1'
 
 export function Me({ loginContext }: Props) {
   const $router = useRouter()
-  if (loginContext?.metadata?.id) {
-    return <User loginContext={loginContext} startTab="settings" />
-  } else {
-    return $router.push(
-      `/login?toast=${btoa('You must be logged in to see that page.')}`
-    )
-  }
+  const [$id, $setId] = useState(NOT_YET_SET)
+  useEffect(() => {
+    if (!$router.isReady) return
+    const id = loginContext?.metadata?.id
+    if (!id) {
+      $router.push(
+        `/login?toast=${btoa('You must be logged in to see that page.')}`
+      )
+    } else {
+      $setId(id.toString())
+    }
+  }, [$router, $router?.isReady, loginContext?.metadata?.id])
+  return $id === NOT_YET_SET ? (
+    <Loader />
+  ) : (
+    <User loginContext={loginContext} startTab="settings" id={$id} />
+  )
 }
 
 export default Me

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -8,12 +8,12 @@ const NOT_YET_SET = '-1'
 
 export function Me({ loginContext }: Props) {
   const $router = useRouter()
-  const { checkLoggedIn } = loginContext
+  const { checkLoggedIn, checkLoading } = loginContext
   const [$id, $setId] = useState(NOT_YET_SET)
   useEffect(() => {
     if (!$router.isReady) return
     const check = () => {
-      if (checkLoggedIn()) {
+      if (checkLoggedIn() && !checkLoading()) {
         const id = loginContext?.metadata?.id
         if (id) {
           // eslint-disable-next-line no-console
@@ -29,7 +29,13 @@ export function Me({ loginContext }: Props) {
       }
     }
     check()
-  }, [$router, $router?.isReady, loginContext?.metadata?.id, checkLoggedIn])
+  }, [
+    $router,
+    $router?.isReady,
+    loginContext?.metadata?.id,
+    checkLoggedIn,
+    checkLoading,
+  ])
   // eslint-disable-next-line no-console
   console.log({
     loginContext,

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -8,35 +8,44 @@ const NOT_YET_SET = '-1'
 
 export function Me({ loginContext }: Props) {
   const $router = useRouter()
-  const { checkLoggedIn, checkLoading } = loginContext
+  const { checkFailed, checkLoggedIn, checkLoading } = loginContext
   // eslint-disable-next-line no-console
   console.log(JSON.stringify(loginContext, null, 2))
   const [$id, $setId] = useState(NOT_YET_SET)
   useEffect(() => {
     if (!$router.isReady) return
     const check = () => {
-      if (checkLoggedIn() && !checkLoading()) {
-        const id = loginContext?.metadata?.id
-        if (id) {
-          // eslint-disable-next-line no-console
-          console.log('I AM LOGGED IN', id)
-          $setId(id.toString())
+      const loggedIn = checkLoggedIn()
+      const loading = checkLoading()
+      const failed = checkFailed()
+      // eslint-disable-next-line no-console
+      console.log({ loggedIn, loading, failed })
+      if ((loggedIn || failed) && !loading) {
+        if (loggedIn) {
+          const id = loginContext?.metadata?.id
+          if (id) {
+            // eslint-disable-next-line no-console
+            console.log('I AM LOGGED IN', id)
+            $setId(id.toString())
+          } else {
+            // eslint-disable-next-line no-console
+            console.log('I AM NOT LOGGED IN')
+            $router.push(
+              `/login?toast=${btoa('You must be logged in to see that page.')}`
+            )
+          }
         }
-      } else {
-        // eslint-disable-next-line no-console
-        console.log('I AM NOT LOGGED IN')
-        $router.push(
-          `/login?toast=${btoa('You must be logged in to see that page.')}`
-        )
       }
     }
-    check()
+    const checkId = setInterval(check, 100)
+    return () => clearInterval(checkId)
   }, [
     $router,
     $router?.isReady,
     loginContext?.metadata?.id,
     checkLoggedIn,
     checkLoading,
+    checkFailed,
   ])
   // eslint-disable-next-line no-console
   console.log({

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -16,9 +16,13 @@ export function Me({ loginContext }: Props) {
       if (checkLoggedIn()) {
         const id = loginContext?.metadata?.id
         if (id) {
+          // eslint-disable-next-line no-console
+          console.log('I AM LOGGED IN', id)
           $setId(id.toString())
         }
       } else {
+        // eslint-disable-next-line no-console
+        console.log('I AM NOT LOGGED IN')
         $router.push(
           `/login?toast=${btoa('You must be logged in to see that page.')}`
         )

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -8,18 +8,24 @@ const NOT_YET_SET = '-1'
 
 export function Me({ loginContext }: Props) {
   const $router = useRouter()
+  const { checkLoggedIn } = loginContext
   const [$id, $setId] = useState(NOT_YET_SET)
   useEffect(() => {
     if (!$router.isReady) return
-    const id = loginContext?.metadata?.id
-    if (!id) {
-      $router.push(
-        `/login?toast=${btoa('You must be logged in to see that page.')}`
-      )
-    } else {
-      $setId(id.toString())
+    const check = () => {
+      if (checkLoggedIn()) {
+        const id = loginContext?.metadata?.id
+        if (id) {
+          $setId(id.toString())
+        }
+      } else {
+        $router.push(
+          `/login?toast=${btoa('You must be logged in to see that page.')}`
+        )
+      }
     }
-  }, [$router, $router?.isReady, loginContext?.metadata?.id])
+    check()
+  }, [$router, $router?.isReady, loginContext?.metadata?.id, checkLoggedIn])
   // eslint-disable-next-line no-console
   console.log({
     loginContext,

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -32,6 +32,7 @@ const validTabValue = (x: string) =>
   x === 'weekly' || x === 'all' || x === 'settings'
 
 export interface Props {
+  id?: string
   loginContext: LoginContext
   startTab?: TabType
 }
@@ -50,14 +51,14 @@ export const LabeledStat = ({ value, label }: LabeledProps) => (
   </div>
 )
 
-export function User({ loginContext, startTab = 'weekly' }: Props) {
+export function User({ id, loginContext, startTab = 'weekly' }: Props) {
   const $toast = useQueriedToast({
     queryString: 'toast',
     duration: 8e3,
   })
   const router = useRouter()
   const { isReady: routerIsReady } = router
-  const userId = (router?.query?.id || '') as string
+  const userId = id || ((router?.query?.id || '') as string)
   const rawTab = useQuery('tab')
   const [$activeTab, $setActiveTab] = useState<TabType>(startTab)
 

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -31,8 +31,9 @@ const EVENTS_LIMIT = 25
 const validTabValue = (x: string) =>
   x === 'weekly' || x === 'all' || x === 'settings'
 
-interface Props {
+export interface Props {
   loginContext: LoginContext
+  startTab?: TabType
 }
 const sumValues = (x: Record<string, number>) =>
   Object.values(x).reduce((a, b) => a + b, 0)
@@ -49,7 +50,7 @@ export const LabeledStat = ({ value, label }: LabeledProps) => (
   </div>
 )
 
-export default function User({ loginContext }: Props) {
+export function User({ loginContext, startTab = 'weekly' }: Props) {
   const $toast = useQueriedToast({
     queryString: 'toast',
     duration: 8e3,
@@ -58,7 +59,7 @@ export default function User({ loginContext }: Props) {
   const { isReady: routerIsReady } = router
   const userId = (router?.query?.id || '') as string
   const rawTab = useQuery('tab')
-  const [$activeTab, $setActiveTab] = useState<TabType>('weekly')
+  const [$activeTab, $setActiveTab] = useState<TabType>(startTab)
 
   const [$user, $setUser] = useState<API.ApiUser | undefined>(undefined)
 
@@ -415,3 +416,5 @@ export default function User({ loginContext }: Props) {
     </div>
   )
 }
+
+export default User


### PR DESCRIPTION
## Summary

If you are on someone else's user page, and you click the button to go to your page, it causes a weird re-render (and re-requests data).

This PR aims to fix that bug by making the button go to a new route: `/me` which is the same as `/users/[your-id]`.

## Testing Plan

👀 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No?
```
