### PR TITLE
Make leaderboard search full width (#188)

### DIFF
--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -188,6 +188,7 @@ export default function Leaderboard({ loginContext }: Props) {
                   'pl-2',
                   'md:pl-5',
                   'h-full',
+                  'w-full',
                   'font-favorit',
                   'bg-transparent',
                   'placeholder-black',


### PR DESCRIPTION
## Summary

I kept clicking in the invisible region and I couldn't find where the
bounds of the search were. This fixes that issue so it makes it so you
can click anywhere in the box.

## Testing Plan

Clicked in search

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
