### PR TITLE
Fix github field sending empty string

### DIFF
--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -29,12 +29,13 @@ export async function createUser(
   socialChoice: string,
   social: string,
   country_code: string,
-  github: string
+  github?: string
 ): Promise<ApiUser | ApiError> {
+  const hub = github ? { github } : {}
   const body = JSON.stringify({
+    ...hub,
     email,
     graffiti,
-    github,
     country_code,
     [socialChoice]: social,
   })

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -65,7 +65,7 @@ export function useField(provided: ProvidedField): Field | null {
     label,
     options,
     radioOption: defaultRadioOption,
-    required = false,
+    required = true,
     touched = false,
     validation,
     whitespace = WHITESPACE.DEFAULT,

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -65,7 +65,7 @@ export function useField(provided: ProvidedField): Field | null {
     label,
     options,
     radioOption: defaultRadioOption,
-    required = true,
+    required = false,
     touched = false,
     validation,
     whitespace = WHITESPACE.DEFAULT,


### PR DESCRIPTION
## Summary

We used to be sending `{github: ''}`, now we are not.

## Testing Plan

Sign up

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and what additional work is required, if any.

```
[ ] Yes
[x] No
```
