### PR TITLE
Responsive one-offs

### DIFF
--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -240,7 +240,7 @@ export default function User({ loginContext }: Props) {
                       'mb-4',
                       'max-w-[32rem]',
                       'md:max-w-[48rem]',
-                      'max-h-[4.3rem]',
+                      'md:h-[4rem]',
                       'overflow-hidden',
                       'truncate'
                     )}

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -240,7 +240,7 @@ export default function User({ loginContext }: Props) {
                       'mb-4',
                       'max-w-[32rem]',
                       'md:max-w-[48rem]',
-                      'max-h-[4rem]',
+                      'max-h-[4.3rem]',
                       'overflow-hidden',
                       'truncate'
                     )}
@@ -305,7 +305,6 @@ export default function User({ loginContext }: Props) {
                   className={clsx(
                     'w-full',
                     'md:w-2/3',
-                    'lg:w-1/2',
                     'flex',
                     'content-between',
                     'justify-between'


### PR DESCRIPTION
## Summary

Change the sizing of the graffiti and prevent second line from showing up at large breakpoints.

Before:

<img src="https://user-images.githubusercontent.com/18919/157724030-37bbde9a-b0d8-4dcd-b486-1bfaeb30e4ca.png">
After:

<img src="https://user-images.githubusercontent.com/18919/157724158-99295633-d6cf-46b2-af04-e6096a959033.png"/>



## Testing Plan

👀 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] Nope
```
