### PR TITLE
Force empty strings for FishAvatar

### DIFF
--- a/utils/graffitiToColor.ts
+++ b/utils/graffitiToColor.ts
@@ -11,7 +11,7 @@ const fishAvatarColors = [
   '#F1CB00',
 ]
 
-export function graffitiToColor(graffiti: string): string {
+export function graffitiToColor(graffiti = ''): string {
   // djb2 (xor)
   let hash = 5381
 


### PR DESCRIPTION
## Summary

1. https://testnet.ironfish.network/users/104 was throwing errors in the `graffitiToColor` function.
2. I resurrected the `jest` tests and wrote a test for the function.
3. I fixed the function and updated the tests.

## Testing Plan

1. `nps care`
2. Updated the github workflow, so it should run automatically now.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and what additional work is required, if any.

```
[ ] Yes
[x] No
```
