### PR TITLE
handle unknown users

### DIFF
--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -5,6 +5,7 @@ import {
   ApiUserMetadata,
   ApiError,
   ApiUser,
+  GenericApiError,
   ListEventsResponse,
   ListLeaderboardResponse,
   MetricsConfigResponse,
@@ -206,4 +207,9 @@ export async function getUserDetails(
   } catch (e) {
     return new LocalError(e.message, ENDPOINT_UNAVAILABLE)
   }
+}
+
+export const isGenericError = (x: GenericApiError) => {
+  const { statusCode } = x
+  return statusCode && statusCode > 400
 }

--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -209,7 +209,9 @@ export async function getUserDetails(
   }
 }
 
-export const isGenericError = (x: GenericApiError) => {
+export const isGenericError = (
+  x: Record<string, unknown>
+): x is GenericApiError => {
   const { statusCode } = x
-  return statusCode && statusCode > 400
+  return typeof statusCode === 'number' && statusCode > 400
 }

--- a/apiClient/types.ts
+++ b/apiClient/types.ts
@@ -111,3 +111,7 @@ export type ApiUserMetadata = {
   statusCode?: number
   message?: string
 }
+
+export type GenericApiError = {
+  statusCode?: number
+}

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -108,10 +108,15 @@ export default function User({ loginContext }: Props) {
 
         if (
           'error' in user ||
+          API.isGenericError(user as API.GenericApiError) ||
           'error' in events ||
+          API.isGenericError(events as API.GenericApiError) ||
           'error' in allTimeMetrics ||
+          API.isGenericError(allTimeMetrics as API.GenericApiError) ||
           'error' in weeklyMetrics ||
-          'error' in metricsConfig
+          API.isGenericError(weeklyMetrics as API.GenericApiError) ||
+          'error' in metricsConfig ||
+          API.isGenericError(metricsConfig as API.GenericApiError)
         ) {
           Router.push(
             `/leaderboard?toast=${btoa(
@@ -154,7 +159,12 @@ export default function User({ loginContext }: Props) {
 
   // Recent Activity hooks
   const { $hasPrevious, $hasNext, fetchPrevious, fetchNext } =
-    usePaginatedEvents(userId, EVENTS_LIMIT, $events, $setEvents)
+    usePaginatedEvents(
+      userId,
+      EVENTS_LIMIT,
+      $events as API.ListEventsResponse,
+      $setEvents
+    )
 
   // Tab hooks
   const onTabChange = useCallback((t: TabType) => {

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -108,15 +108,15 @@ export default function User({ loginContext }: Props) {
 
         if (
           'error' in user ||
-          API.isGenericError(user as API.GenericApiError) ||
+          API.isGenericError(user) ||
           'error' in events ||
-          API.isGenericError(events as API.GenericApiError) ||
+          API.isGenericError(events) ||
           'error' in allTimeMetrics ||
-          API.isGenericError(allTimeMetrics as API.GenericApiError) ||
+          API.isGenericError(allTimeMetrics) ||
           'error' in weeklyMetrics ||
-          API.isGenericError(weeklyMetrics as API.GenericApiError) ||
+          API.isGenericError(weeklyMetrics) ||
           'error' in metricsConfig ||
-          API.isGenericError(metricsConfig as API.GenericApiError)
+          API.isGenericError(metricsConfig)
         ) {
           Router.push(
             `/leaderboard?toast=${btoa(
@@ -159,12 +159,7 @@ export default function User({ loginContext }: Props) {
 
   // Recent Activity hooks
   const { $hasPrevious, $hasNext, fetchPrevious, fetchNext } =
-    usePaginatedEvents(
-      userId,
-      EVENTS_LIMIT,
-      $events as API.ListEventsResponse,
-      $setEvents
-    )
+    usePaginatedEvents(userId, EVENTS_LIMIT, $events, $setEvents)
 
   // Tab hooks
   const onTabChange = useCallback((t: TabType) => {


### PR DESCRIPTION
## Summary

If you go to a user ID which doesn't exist, our frontend didn't deal with the missing data correctly:

e.g. testnet.ironfish.network/users/100000

## Testing Plan

Go to `/users/[some-number-which-doesn't-exist-as-a-user-id]`

## Breaking Change

No, it's a fixing change.
