### PR TITLE
Staging -> Master

### DIFF
--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -7,7 +7,7 @@ import {
   ApiUser,
   GenericApiError,
   ListEventsResponse,
-  ListLeaderboardResponse,
+  PaginatedListLeaderboardResponse,
   MetricsConfigResponse,
   UserMetricsResponse,
 } from './types'
@@ -74,15 +74,21 @@ export async function updateUser(id: number, partial: PartialUser) {
   return await res.json()
 }
 
-export async function listLeaderboard({
+export async function listUsers({
   search,
   country_code: countryCode,
   event_type: eventType,
+  limit,
+  after,
+  before,
 }: {
   search?: string
   country_code?: string
   event_type?: string
-} = {}): Promise<ListLeaderboardResponse | ApiError> {
+  limit?: number
+  after?: number
+  before?: number
+}): Promise<PaginatedListLeaderboardResponse | ApiError> {
   const params = new URLSearchParams({
     order_by: 'rank',
   })
@@ -95,6 +101,16 @@ export async function listLeaderboard({
   if (eventType) {
     params.append('event_type', eventType)
   }
+  if (after) {
+    params.append('after', after.toString())
+  }
+  if (before) {
+    params.append('before', before.toString())
+  }
+  if (limit) {
+    params.append('limit', limit.toString())
+  }
+
   const res = await fetch(`${API_URL}/users?${params.toString()}`)
   return await res.json()
 }

--- a/apiClient/types.ts
+++ b/apiClient/types.ts
@@ -55,16 +55,23 @@ export type ApiError = {
   error: string
 }
 
-export type ListEventsResponse = {
-  data: ReadonlyArray<ApiEvent>
-  metadata: {
-    has_next: boolean
-    has_previous: boolean
-  }
+export interface Pagination {
+  has_next: boolean
+  has_previous: boolean
 }
 
-export type ListLeaderboardResponse = {
+export type ListEventsResponse = {
+  data: ReadonlyArray<ApiEvent>
+  metadata: Pagination
+}
+
+export interface ListLeaderboardResponse {
   data: ReadonlyArray<ApiUser>
+}
+
+export interface PaginatedListLeaderboardResponse
+  extends ListLeaderboardResponse {
+  metadata: Pagination
 }
 
 export type UserMetric = {

--- a/components/About/data.tsx
+++ b/components/About/data.tsx
@@ -195,7 +195,7 @@ export const callsToAction = {
       content:
         'Let us know if you have suggestions for other categories we should add!',
       ctaText: 'Reach out on Discord',
-      href: 'https://discord.com/invite/EkQkEcm8DH',
+      href: 'https://discord.gg/ironfish',
       earn: 0,
       kind: 'coming soon',
     },

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -125,7 +125,7 @@ function Footer() {
                 alt="Twitter"
               />
             </a>
-            <a href="https://discord.gg/EkQkEcm8DH">
+            <a href="https://discord.gg/ironfish">
               <Image
                 src="/footer/discord.svg"
                 layout="fixed"

--- a/components/PaginationButton.tsx
+++ b/components/PaginationButton.tsx
@@ -7,11 +7,7 @@ type Props = {
   children?: React.ReactNode
 }
 
-function EventsPaginationButton({
-  children,
-  disabled = false,
-  onClick,
-}: Props) {
+function PaginationButton({ children, disabled = false, onClick }: Props) {
   return (
     <button
       className={clsx({
@@ -26,4 +22,4 @@ function EventsPaginationButton({
   )
 }
 
-export default EventsPaginationButton
+export default PaginationButton

--- a/cypress/integration/pages/about.ts
+++ b/cypress/integration/pages/about.ts
@@ -100,7 +100,7 @@ describe('/about', () => {
       {
         isImage: false,
         text: 'Reach out on Discord',
-        href: 'https://discord.com/invite/EkQkEcm8DH',
+        href: 'https://discord.gg/ironfish',
       },
       {
         isImage: false,
@@ -156,7 +156,7 @@ describe('/about', () => {
         text: 'Twitter',
         href: 'https://twitter.com/ironfishcrypto',
       },
-      { isImage: true, text: 'Discord', href: 'https://discord.gg/EkQkEcm8DH' },
+      { isImage: true, text: 'Discord', href: 'https://discord.gg/ironfish' },
     ])
   })
 })

--- a/hooks/usePaginatedUsers.ts
+++ b/hooks/usePaginatedUsers.ts
@@ -1,0 +1,65 @@
+import { Dispatch, SetStateAction, useCallback, useMemo } from 'react'
+import * as API from 'apiClient'
+
+type PaginatedUsers = {
+  $hasPrevious: boolean
+  $hasNext: boolean
+  fetchPrevious: () => void
+  fetchNext: () => void
+}
+
+export function usePaginatedUsers(
+  limit: number,
+  search: string,
+  eventType: string,
+  countryCode: string,
+  users: API.PaginatedListLeaderboardResponse | undefined,
+  setUsers: Dispatch<
+    SetStateAction<API.PaginatedListLeaderboardResponse | undefined>
+  >
+): PaginatedUsers {
+  const $hasPrevious = useMemo(
+    () => users?.metadata.has_previous ?? false,
+    [users]
+  )
+  const $hasNext = useMemo(() => users?.metadata.has_next ?? false, [users])
+
+  const fetchUsers = useCallback(
+    async (id: number, direction: 'before' | 'after') => {
+      const raw = { [direction]: id.toString() }
+
+      const countrySearch =
+        countryCode !== 'Global' ? { country_code: countryCode } : {}
+
+      const eventTypeData =
+        eventType !== 'Total Points' ? { event_type: eventType } : {}
+
+      const result = await API.listUsers({
+        limit,
+        ...raw,
+        ...countrySearch,
+        ...eventTypeData,
+      })
+
+      if (!('error' in result)) {
+        setUsers(result)
+      }
+    },
+    [setUsers, limit, countryCode, eventType]
+  )
+
+  const fetchNext = useCallback(
+    async () =>
+      users && fetchUsers(users.data[users.data.length - 1].id, 'after'),
+    [fetchUsers, users]
+  )
+
+  const fetchPrevious = useCallback(
+    async () => users && fetchUsers(users.data[0].id, 'before'),
+    [fetchUsers, users]
+  )
+
+  return { $hasPrevious, $hasNext, fetchPrevious, fetchNext }
+}
+
+export default usePaginatedUsers

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -105,7 +105,7 @@ testnet. If you're looking for more detailed answers, or you
 don't see the question that you'd like to ask, please reach out
 on our `}
     <span className="underline">
-      <Link href="https://discord.com/invite/EkQkEcm8DH">Discord server</Link>
+      <Link href="https://discord.gg/ironfish">Discord server</Link>
     </span>
     .
   </span>

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -212,6 +212,7 @@ export default function Leaderboard({ loginContext }: Props) {
                     'pl-2',
                     'md:pl-5',
                     'h-full',
+                    'w-full',
                     'font-favorit',
                     'bg-transparent',
                     'placeholder-black',

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -10,6 +10,11 @@ import BackToTop from 'components/BackToTop'
 import { Select } from 'components/Form/Select'
 import PageBanner from 'components/PageBanner'
 import { Toast, Alignment } from 'components/Toast'
+import NoResults from 'components/leaderboard/ImageNoResults'
+import LeaderboardRow from 'components/leaderboard/LeaderboardRow'
+import Loader from 'components/Loader'
+import CountdownTimer from 'components/leaderboard/CountdownTimer'
+import PaginationButton from 'components/PaginationButton'
 
 import { countries, CountryWithCode } from 'data/countries'
 import { defaultErrorText } from 'utils/forms'
@@ -17,13 +22,9 @@ import useDebounce from 'hooks/useDebounce'
 import { LoginContext } from 'hooks/useLogin'
 import { useField } from 'hooks/useForm'
 import { useQueriedToast } from 'hooks/useToast'
+import { usePaginatedUsers } from 'hooks/usePaginatedUsers'
 
 import * as API from 'apiClient'
-import NoResults from 'components/leaderboard/ImageNoResults'
-import LeaderboardRow from 'components/leaderboard/LeaderboardRow'
-import Loader from 'components/Loader'
-
-import CountdownTimer from 'components/leaderboard/CountdownTimer'
 
 type Props = {
   loginContext: LoginContext
@@ -64,6 +65,8 @@ const FIELDS = {
 }
 const CTA = `Our incentivized testnet leaderboard shows you who the top point getters are for all-time score, miners, bug catchers, net promoters, node hosting, and more! Click someone’s user name to see a breakdown of their activity. Points are earned during weekly cycles which begin Monday, 12:00am UTC and end Sunday 11:59pm UTC.`
 
+const PAGINATION_LIMIT = 25
+
 export default function Leaderboard({ loginContext }: Props) {
   const { visible: $visible, message: $toast } = useQueriedToast({
     queryString: 'toast',
@@ -72,7 +75,9 @@ export default function Leaderboard({ loginContext }: Props) {
 
   const $country = useField(FIELDS.country)
   const $eventType = useField(FIELDS.eventType)
-  const [$users, $setUsers] = useState<ReadonlyArray<API.ApiUser>>([])
+  const [$userList, $setUserList] = useState<
+    API.PaginatedListLeaderboardResponse | undefined
+  >()
 
   // Search field hooks
   const [$search, $setSearch] = useState('')
@@ -91,14 +96,15 @@ export default function Leaderboard({ loginContext }: Props) {
       const eventType =
         eventTypeValue !== TOTAL_POINTS ? { event_type: eventTypeValue } : {}
 
-      const result = await API.listLeaderboard({
+      const result = await API.listUsers({
+        limit: PAGINATION_LIMIT,
         search: $debouncedSearch,
         ...countrySearch,
         ...eventType,
       })
 
       if (!('error' in result)) {
-        $setUsers(result.data)
+        $setUserList(result)
       }
 
       $setSearching(false)
@@ -112,6 +118,17 @@ export default function Leaderboard({ loginContext }: Props) {
   const { checkLoggedIn, checkLoading } = loginContext
   const isLoggedIn = checkLoggedIn()
   const isLoading = checkLoading()
+
+  const { fetchPrevious, fetchNext, $hasPrevious, $hasNext } =
+    usePaginatedUsers(
+      PAGINATION_LIMIT,
+      $search,
+      $eventType?.value || '',
+      $country?.value || '',
+      $userList,
+      $setUserList
+    )
+  const users = $userList?.data || []
 
   return isLoading ? (
     <Loader />
@@ -286,7 +303,7 @@ export default function Leaderboard({ loginContext }: Props) {
               'mb-4'
             )}
           >
-            {$users.length > 0 && (
+            {users.length > 0 && (
               <>
                 <div className={clsx('w-16', 'sm:w-24', 'hidden', 'md:inline')}>
                   RANK
@@ -294,7 +311,7 @@ export default function Leaderboard({ loginContext }: Props) {
                 <div className={clsx('flex-1', 'hidden', 'md:inline')}>
                   USERNAME
                 </div>
-                <div className={clsx('ml-2', '', 'hidden', 'md:inline')}>
+                <div className={clsx('ml-2', 'hidden', 'md:inline')}>
                   TOTAL POINTS
                 </div>
               </>
@@ -302,10 +319,10 @@ export default function Leaderboard({ loginContext }: Props) {
           </div>
           {$searching ? (
             <Loader />
-          ) : $users.length === 0 ? (
+          ) : users.length === 0 ? (
             <NoResults />
           ) : (
-            $users.map(user => (
+            users.map(user => (
               <div className="mb-3" key={user.id}>
                 <Link href={`/users/${user.id}`}>
                   <a>
@@ -319,8 +336,23 @@ export default function Leaderboard({ loginContext }: Props) {
               </div>
             ))
           )}
-          <div className="mb-24"></div>
+          <div
+            className={clsx('flex', 'font-favorit', 'justify-center', 'mt-8')}
+          >
+            <div className={clsx('flex', 'gap-x-1.5')}>
+              <PaginationButton
+                disabled={!$hasPrevious}
+                onClick={fetchPrevious}
+              >{`<< Previous`}</PaginationButton>
+              <div>{`|`}</div>
+              <PaginationButton
+                disabled={!$hasNext}
+                onClick={fetchNext}
+              >{`Next >>`}</PaginationButton>
+            </div>
+          </div>
         </div>
+        <div className="mb-24"></div>
       </main>
       <Footer />
     </div>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -235,7 +235,7 @@ export default function SignUp({ loginContext }: SignUpProps) {
                           </Note>
                           <p className="p-2 text-center text-sm">
                             Have any questions for our team?{' '}
-                            <Link href="https://discord.gg/EkQkEcm8DH">
+                            <Link href="https://discord.gg/ironfish">
                               <a className=" text-iflightblue">
                                 Find us on Discord.
                               </a>

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -9,7 +9,7 @@ import Footer from 'components/Footer'
 import Navbar from 'components/Navbar'
 import Loader from 'components/Loader'
 import { Container as OffsetBorderContainer } from 'components/OffsetBorder'
-import EventsPaginationButton from 'components/user/EventsPaginationButton'
+import PaginationButton from 'components/PaginationButton'
 import FishAvatar from 'components/user/FishAvatar'
 import Flag from 'components/user/Flag'
 import Tabs, { TabType } from 'components/user/Tabs'
@@ -396,15 +396,15 @@ export default function User({ loginContext }: Props) {
               className={clsx('flex', 'font-favorit', 'justify-center', 'mt-8')}
             >
               <div className={clsx('flex', 'gap-x-1.5')}>
-                <EventsPaginationButton
+                <PaginationButton
                   disabled={!$hasPrevious}
                   onClick={fetchPrevious}
-                >{`<< Previous`}</EventsPaginationButton>
+                >{`<< Previous`}</PaginationButton>
                 <div>{`|`}</div>
-                <EventsPaginationButton
+                <PaginationButton
                   disabled={!$hasNext}
                   onClick={fetchNext}
-                >{`Next >>`}</EventsPaginationButton>
+                >{`Next >>`}</PaginationButton>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary

- [Discord links update](https://github.com/iron-fish/website-testnet/pull/211)
- [User Pagination](https://github.com/iron-fish/website-testnet/pull/205)
- [Search / Filter updates](https://github.com/iron-fish/website-testnet/pull/202) for mobile which somehow got eaten last release

## Testing Plan

- Paginate back and forth on `/leaderboard` 
<img width="188" alt="CleanShot 2022-03-18 at 10 32 49@2x" src="https://user-images.githubusercontent.com/18919/159054028-7e951648-90b1-49be-a4fe-059e410d7856.png">

- Click discord links (if you are so inclined)
- Check out the Search / Filter UI on `/leaderboard` at a mobile width, it should look like this: 
<img width="401" alt="CleanShot 2022-03-18 at 10 32 07@2x" src="https://user-images.githubusercontent.com/18919/159053922-5b1af344-3e09-464c-870e-8d4893f85cb0.png">


## Breaking Change

```
[ ] Yes
[x] No
```
