### PR TITLE
Update useForm `defaultValue` behaviors

### DIFF
--- a/components/Form/FormRow.tsx
+++ b/components/Form/FormRow.tsx
@@ -1,3 +1,5 @@
+import clsx from 'clsx'
+
 interface FormRowProps {
   className?: string
   valid: boolean
@@ -20,11 +22,30 @@ export const FormRow = ({
   disabled,
   children,
 }: FormRowProps) => {
+  // eslint-disable-next-line no-console
+  console.log({ formRow: 'formy form form', valid })
   const borderColor = getBorderColor(valid, disabled)
   const textColor = disabled ? 'text-ifsubtextgray' : ''
   return (
     <div
-      className={`font-favorit flex flex-col px-4 py-3 mt-4 w-full border rounded-plus border-solid h-16 max-h-16 max-w-md ${borderColor} ${textColor} ${className}`}
+      className={clsx(
+        'font-favorit',
+        'flex',
+        'flex-col',
+        'px-4',
+        'py-3',
+        'mt-4',
+        'w-full',
+        'border',
+        'rounded-plus',
+        'border-solid',
+        'h-16',
+        'max-h-16',
+        'max-w-md',
+        borderColor,
+        textColor,
+        className
+      )}
     >
       {children}
     </div>

--- a/components/Form/FormRow.tsx
+++ b/components/Form/FormRow.tsx
@@ -22,8 +22,6 @@ export const FormRow = ({
   disabled,
   children,
 }: FormRowProps) => {
-  // eslint-disable-next-line no-console
-  console.log({ formRow: 'formy form form', valid })
   const borderColor = getBorderColor(valid, disabled)
   const textColor = disabled ? 'text-ifsubtextgray' : ''
   return (

--- a/components/Form/TextField.tsx
+++ b/components/Form/TextField.tsx
@@ -72,8 +72,6 @@ export const TextField = ({
   value,
   controlled = false,
 }: ControlledField) => {
-  // eslint-disable-next-line no-console
-  console.log({ valid, textField: 'text valid valid ?' })
   const handleTrim = whitespace !== WHITESPACE.DEFAULT ? { onKeyDown } : {}
   const controller = controlled ? { value: value } : {}
   const inputProps = {

--- a/components/Form/TextField.tsx
+++ b/components/Form/TextField.tsx
@@ -72,6 +72,8 @@ export const TextField = ({
   value,
   controlled = false,
 }: ControlledField) => {
+  // eslint-disable-next-line no-console
+  console.log({ valid, textField: 'text valid valid ?' })
   const handleTrim = whitespace !== WHITESPACE.DEFAULT ? { onKeyDown } : {}
   const controller = controlled ? { value: value } : {}
   const inputProps = {

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -76,8 +76,6 @@ export function useField(provided: ProvidedField): Field | null {
   const touched = defaultValue ? true : _touched
 
   const initiallyValid = defaultValue ? validation(defaultValue) : false
-  // eslint-disable-next-line no-console
-  console.log({ defaultValue, touched, _touched, initiallyValid })
   const [$value, $setter] = useState<string>(defaultValue)
   const radioOption =
     defaultRadioOption || (options && options[0] && options[0].value)
@@ -89,6 +87,8 @@ export function useField(provided: ProvidedField): Field | null {
   const [$disabled, $setDisabled] = useState<boolean>(false)
   const [, $setValid] = useState<boolean>(initiallyValid)
   const [$touched, $setTouched] = useState<boolean>(touched)
+  // eslint-disable-next-line no-console
+  console.log({ defaultValue, touched, _touched, $touched, initiallyValid })
   const [$field, $setField] = useState<Field | null>(null)
   const [$error, $setError] = useState<string>(defaultErrorText)
   useEffect(() => {

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -86,7 +86,7 @@ export function useField(provided: ProvidedField): Field | null {
     isRadioed && radioOption ? radioOption : ''
   )
   const [$disabled, $setDisabled] = useState<boolean>(false)
-  const [, $setValid] = useState<boolean>(initiallyValid)
+  const [$valid, $setValid] = useState<boolean>(initiallyValid)
   const [$touched, $setTouched] = useState<boolean>(touched)
   // eslint-disable-next-line no-console
   console.log(
@@ -96,8 +96,15 @@ export function useField(provided: ProvidedField): Field | null {
   const [$field, $setField] = useState<Field | null>(null)
   const [$error, $setError] = useState<string>(defaultErrorText)
   useEffect(() => {
-    const valid = !$touched || ($touched && validation($value))
-    $setValid(valid)
+    if (defaultValue) {
+      $setTouched(true)
+      $setValid(validation(defaultValue))
+    } else {
+      const valid = !$touched || ($touched && validation($value))
+      $setValid(valid)
+    }
+  }, [$touched, defaultValue, validation, $value])
+  useEffect(() => {
     $setField({
       // raw values from upstream
       defaultErrorText,
@@ -108,7 +115,7 @@ export function useField(provided: ProvidedField): Field | null {
       label,
       radioOption: defaultRadioOption,
       options,
-      valid,
+      valid: $valid,
       validation,
       whitespace,
       placeholder,
@@ -116,7 +123,7 @@ export function useField(provided: ProvidedField): Field | null {
       // dynamic values
       choice: $choice,
       disabled: $disabled,
-      errorText: valid ? undefined : $error,
+      errorText: $valid ? undefined : $error,
       onChange: setStateOnChange($setter, trimSpaces),
       setChoice: $setChoice,
       setDisabled: $setDisabled,
@@ -139,6 +146,7 @@ export function useField(provided: ProvidedField): Field | null {
       controlled,
     })
   }, [
+    $valid,
     defaultLabel,
     defaultErrorText,
     defaultRadioOption,

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -89,6 +89,11 @@ export function useField(provided: ProvidedField): Field | null {
   const [$field, $setField] = useState<Field | null>(null)
   const [$error, $setError] = useState<string>(defaultErrorText)
   useEffect(() => {
+    if (defaultValue) {
+      $setTouched(true)
+    }
+  }, [defaultValue])
+  useEffect(() => {
     const valid = !$touched || ($touched && validation($value))
     $setValid(valid)
   }, [$touched, validation, $value])

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -74,6 +74,10 @@ export function useField(provided: ProvidedField): Field | null {
     touched: _touched = false,
   } = provided
   const touched = defaultValue ? true : _touched
+
+  const initiallyValid = defaultValue ? validation(defaultValue) : false
+  // eslint-disable-next-line no-console
+  console.log({ defaultValue, touched, _touched, initiallyValid })
   const [$value, $setter] = useState<string>(defaultValue)
   const radioOption =
     defaultRadioOption || (options && options[0] && options[0].value)
@@ -83,9 +87,7 @@ export function useField(provided: ProvidedField): Field | null {
     isRadioed && radioOption ? radioOption : ''
   )
   const [$disabled, $setDisabled] = useState<boolean>(false)
-  const [, $setValid] = useState<boolean>(
-    defaultValue ? validation(defaultValue) : false
-  )
+  const [, $setValid] = useState<boolean>(initiallyValid)
   const [$touched, $setTouched] = useState<boolean>(touched)
   const [$field, $setField] = useState<Field | null>(null)
   const [$error, $setError] = useState<string>(defaultErrorText)

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -74,8 +74,9 @@ export function useField(provided: ProvidedField): Field | null {
     touched: _touched = false,
   } = provided
   const touched = defaultValue ? true : _touched
-
   const initiallyValid = defaultValue ? validation(defaultValue) : false
+  // eslint-disable-next-line no-console
+  console.log({ defaultValue, touched, _touched, initiallyValid }, 'YO')
   const [$value, $setter] = useState<string>(defaultValue)
   const radioOption =
     defaultRadioOption || (options && options[0] && options[0].value)
@@ -88,7 +89,10 @@ export function useField(provided: ProvidedField): Field | null {
   const [, $setValid] = useState<boolean>(initiallyValid)
   const [$touched, $setTouched] = useState<boolean>(touched)
   // eslint-disable-next-line no-console
-  console.log({ defaultValue, touched, _touched, $touched, initiallyValid })
+  console.log(
+    { defaultValue, touched, _touched, $touched, initiallyValid },
+    'YO YO'
+  )
   const [$field, $setField] = useState<Field | null>(null)
   const [$error, $setError] = useState<string>(defaultErrorText)
   useEffect(() => {

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -89,14 +89,9 @@ export function useField(provided: ProvidedField): Field | null {
   const [$field, $setField] = useState<Field | null>(null)
   const [$error, $setError] = useState<string>(defaultErrorText)
   useEffect(() => {
-    if (defaultValue) {
-      $setTouched(true)
-      $setValid(validation(defaultValue))
-    } else {
-      const valid = !$touched || ($touched && validation($value))
-      $setValid(valid)
-    }
-  }, [$touched, defaultValue, validation, $value])
+    const valid = !$touched || ($touched && validation($value))
+    $setValid(valid)
+  }, [$touched, validation, $value])
   useEffect(() => {
     $setField({
       // raw values from upstream

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -66,15 +66,15 @@ export function useField(provided: ProvidedField): Field | null {
     options,
     radioOption: defaultRadioOption,
     required = true,
-    touched = false,
     validation,
     whitespace = WHITESPACE.DEFAULT,
     placeholder,
     useDefault,
     controlled,
+    touched: _touched = false,
   } = provided
+  const touched = defaultValue ? true : _touched
   const [$value, $setter] = useState<string>(defaultValue)
-  // TODO: tried writing this with nullish coalescing but it yelled and I got tired
   const radioOption =
     defaultRadioOption || (options && options[0] && options[0].value)
   const banSpaces = whitespace === WHITESPACE.BANNED
@@ -83,7 +83,9 @@ export function useField(provided: ProvidedField): Field | null {
     isRadioed && radioOption ? radioOption : ''
   )
   const [$disabled, $setDisabled] = useState<boolean>(false)
-  const [, $setValid] = useState<boolean>(false)
+  const [, $setValid] = useState<boolean>(
+    defaultValue ? validation(defaultValue) : false
+  )
   const [$touched, $setTouched] = useState<boolean>(touched)
   const [$field, $setField] = useState<Field | null>(null)
   const [$error, $setError] = useState<string>(defaultErrorText)

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -75,8 +75,6 @@ export function useField(provided: ProvidedField): Field | null {
   } = provided
   const touched = defaultValue ? true : _touched
   const initiallyValid = defaultValue ? validation(defaultValue) : false
-  // eslint-disable-next-line no-console
-  console.log({ defaultValue, touched, _touched, initiallyValid }, 'YO')
   const [$value, $setter] = useState<string>(defaultValue)
   const radioOption =
     defaultRadioOption || (options && options[0] && options[0].value)
@@ -88,11 +86,6 @@ export function useField(provided: ProvidedField): Field | null {
   const [$disabled, $setDisabled] = useState<boolean>(false)
   const [$valid, $setValid] = useState<boolean>(initiallyValid)
   const [$touched, $setTouched] = useState<boolean>(touched)
-  // eslint-disable-next-line no-console
-  console.log(
-    { defaultValue, touched, _touched, $touched, initiallyValid },
-    'YO YO'
-  )
   const [$field, $setField] = useState<Field | null>(null)
   const [$error, $setError] = useState<string>(defaultErrorText)
   useEffect(() => {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -63,11 +63,7 @@ export default function Login({ showNotification, loginContext }: LoginProps) {
   const [$error, $setError] = useState<string>(UNSET)
   const [$loaded, $setLoaded] = useState<boolean>(false)
   const $email = useField(FIELDS.email)
-  useEffect(() => {
-    if ($queryEmail && FIELDS.email.validation($queryEmail) && $email) {
-      $email.setTouched(true)
-    }
-  }, [$queryEmail, $email])
+
   const textFields = [$email]
   const testInvalid = useCallback(() => {
     const noEmail = !$email?.touched


### PR DESCRIPTION
## Summary

1. Set the internal `touched` value based on a given `defaultValue`
2. Segment validation as a separate `useEffect`

## Testing Plan

This previously [merged PR](https://github.com/iron-fish/website-testnet/pull/225) was a quick fix. With this PR's changes, we can see the same behavior without the one-off `useEffect`.

1. Working: https://website-testnet-git-update-form-checkery-ironfish.vercel.app/login?email=cool@gmail.com
2. Also working (but invalid email): https://website-testnet-git-update-form-checkery-ironfish.vercel.app/login?email=coolcoolcoolemail

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] Hopefully not
```
