### PR TITLE
Remove duplicate API_URL env variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,3 @@
 NEXT_PUBLIC_API_URL=https://api-staging.ironfish.network
-API_URL=https://api-staging.ironfish.network
 NEXT_PUBLIC_MAGIC_PUBLISHABLE_KEY=test
 NEXT_PUBLIC_LOCAL_USER=true

--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -18,11 +18,7 @@ import {
   NOT_ISOMORPHIC,
 } from 'constants/errors'
 
-// Environment variables set in Vercel config.
-const SERVER_API_URL = process.env.API_URL
-const BROWSER_API_URL = process.env.NEXT_PUBLIC_API_URL
-
-export const API_URL = SERVER_API_URL || BROWSER_API_URL
+export const API_URL = process.env.NEXT_PUBLIC_API_URL
 
 export async function createUser(
   email: string,


### PR DESCRIPTION
## Summary

This variable duplicates the one that already exists. The documentation
explains that you don't need both, as public variables are also
available to the server as well. They are just inlined into the served
page for the frontend to also consume.

https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser

```
This loads process.env.NEXT_PUBLIC_ANALYTICS_ID into the Node.js environment automatically, allowing you to use it anywhere in your code. The value will be inlined into JavaScript sent to the browser because of the NEXT_PUBLIC_ prefix.
```

## Testing Plan

Added console logs for both environment variables, and saw that both environments could see NEXT_PUBLIC_ANALYTICS_ID but not API_URL.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
