### PR TITLE
Fix leaderboard link to phase 1

### DIFF
--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -173,7 +173,7 @@ export default function Leaderboard({ showNotification, loginContext }: Props) {
               getters are for all-time score, miners, bug catchers, net
               promoters, node hosting and more! Click a user name to see a
               breakdown of their activity.{' '}
-              <Link href="phase1.testnet.ironfish.network" passHref>
+              <Link href="https://phase1.testnet.ironfish.network" passHref>
                 <a className="border-b border-black">
                   View Phase 1 leaderboard
                 </a>


### PR DESCRIPTION
## Summary

The link to phase 1 goes to the wrong URL, because it doesn't have a
protocol so the browser treats it as a relative URL.

## Testing Plan

View the link on the leaderboard.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
