### PR TITLE
Update key for transaction events

### DIFF
--- a/apiClient/types.ts
+++ b/apiClient/types.ts
@@ -17,7 +17,8 @@ export type ApiEventMetadataWithLink = {
 }
 
 export type ApiEventMetadataTransactionSent = {
-  hash: string
+  transaction_hash: string
+  block_hash: string
 }
 
 export type ApiEventMetadata =

--- a/components/user/EventRow.tsx
+++ b/components/user/EventRow.tsx
@@ -98,7 +98,7 @@ const makeLinkForEvent = (type: EventType, metadata?: ApiEventMetadata) => {
     'block_hash' in metadata &&
     type === EventType.TRANSACTION_SENT
   ) {
-    return `https://explorer.ironfish.network/${metadata.transaction_hash}/${metadata.block_hash}`
+    return `https://explorer.ironfish.network/transaction/${metadata.transaction_hash}/${metadata.block_hash}`
   }
   if ('hash' in metadata && type === EventType.BLOCK_MINED) {
     return `https://explorer.ironfish.network/blocks/${metadata.hash}`

--- a/components/user/EventRow.tsx
+++ b/components/user/EventRow.tsx
@@ -98,7 +98,7 @@ const makeLinkForEvent = (type: EventType, metadata?: ApiEventMetadata) => {
     'block_hash' in metadata &&
     type === EventType.TRANSACTION_SENT
   ) {
-    return `https://explorer.ironfish.network/${metadata.block_hash}/${metadata.transaction_hash}`
+    return `https://explorer.ironfish.network/${metadata.transaction_hash}/${metadata.block_hash}`
   }
   if ('hash' in metadata && type === EventType.BLOCK_MINED) {
     return `https://explorer.ironfish.network/blocks/${metadata.hash}`

--- a/components/user/EventRow.tsx
+++ b/components/user/EventRow.tsx
@@ -93,6 +93,13 @@ export type EventRowProps = {
 
 const makeLinkForEvent = (type: EventType, metadata?: ApiEventMetadata) => {
   if (!metadata) return ''
+  if (
+    'transaction_hash' in metadata &&
+    'block_hash' in metadata &&
+    type === EventType.TRANSACTION_SENT
+  ) {
+    return `https://explorer.ironfish.network/${metadata.block_hash}/${metadata.transaction_hash}`
+  }
   if ('hash' in metadata && type === EventType.BLOCK_MINED) {
     return `https://explorer.ironfish.network/blocks/${metadata.hash}`
   }
@@ -177,8 +184,8 @@ const summarizeEvent = (
     return <CopyableHash hash={hash} />
   }
   if (type === EventType.TRANSACTION_SENT) {
-    const { hash } = metadata as ApiEventMetadataTransactionSent
-    return <CopyableHash hash={hash} unit="Txn" />
+    const { transaction_hash } = metadata as ApiEventMetadataTransactionSent
+    return <CopyableHash hash={transaction_hash} unit="Txn" />
   }
   const { url } = metadata as ApiEventMetadataWithLink
   const link = new URL(url)


### PR DESCRIPTION
- Change the key from `hash` to `transaction_hash` for the EventRow summaries
- Updated link so that it correctly formats the transaction_hash/block_hash