### PR TITLE
UI Fixes

### DIFF
--- a/components/OffsetBorder/Box.tsx
+++ b/components/OffsetBorder/Box.tsx
@@ -30,7 +30,15 @@ export function Box({
           behind
         )}
       />
-      <div className={clsx('relative', 'border', 'border-black', background)}>
+      <div
+        className={clsx(
+          'relative',
+          'border',
+          'border-black',
+          'h-full',
+          background
+        )}
+      >
         {children}
       </div>
     </div>

--- a/components/leaderboard/LeaderboardRow.tsx
+++ b/components/leaderboard/LeaderboardRow.tsx
@@ -111,7 +111,8 @@ function LeaderboardRow({ rank, graffiti, points = 0 }: Props) {
           'font-extended',
           'text-2xl',
           'w-16',
-          'sm:w-24'
+          'sm:w-24',
+          'truncate'
         )}
       >
         {rankStr}

--- a/components/user/GenericMetricCard.tsx
+++ b/components/user/GenericMetricCard.tsx
@@ -57,8 +57,8 @@ export function GenericMetricCard({
           >
             {title}
           </div>
-          <div className={clsx('flex', 'gap-4')}>
-            <div className="text-5xl">{value}</div>
+          <div className={clsx('flex', 'gap-3')}>
+            <div className="text-4xl">{value}</div>
             <div className={clsx('font-favorit', 'mt-1', 'overflow-hidden')}>
               <div className="leading-tight">{top}</div>
               <div

--- a/components/user/TimeCard.tsx
+++ b/components/user/TimeCard.tsx
@@ -55,8 +55,8 @@ export function GenericUptimeCard({
           >
             {title}
           </div>
-          <div className={clsx('flex', 'gap-4')}>
-            <div className="text-5xl">{value}</div>
+          <div className={clsx('flex', 'gap-3')}>
+            <div className="text-4xl">{value}</div>
             <div className={clsx('font-favorit', 'mt-1', 'overflow-hidden')}>
               <div className="leading-tight">{top}</div>
               <div

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -212,7 +212,7 @@ export default function User({ showNotification, loginContext }: Props) {
           'overflow-hidden'
         )}
       >
-        <div style={{ flexBasis: 1138 }}>
+        <div style={{ flexBasis: 1138, width: '100%' }}>
           <OffsetBorderContainer>
             <div
               className={clsx(
@@ -230,7 +230,7 @@ export default function User({ showNotification, loginContext }: Props) {
                 className={clsx('flex', 'justify-between', 'md:mb-8')}
                 style={{ width: '100%' }}
               >
-                <div className={clsx('flex', 'flex-col')}>
+                <div className={clsx('flex', 'flex-col', 'overflow-hidden')}>
                   <h1
                     className={clsx(
                       'font-extended',

--- a/utils/numberToOrdinal.ts
+++ b/utils/numberToOrdinal.ts
@@ -7,13 +7,13 @@ export function numberToOrdinal(num: number): string {
   const k = num % 100
 
   if (j === 1 && k !== 11) {
-    return `${num.toLocaleString()}st`
+    return `${num}st`
   }
   if (j == 2 && k != 12) {
-    return `${num.toLocaleString()}nd`
+    return `${num}nd`
   }
   if (j == 3 && k != 13) {
-    return `${num.toLocaleString()}rd`
+    return `${num}rd`
   }
-  return `${num.toLocaleString()}th`
+  return `${num}th`
 }

--- a/utils/numberToOrdinal.ts
+++ b/utils/numberToOrdinal.ts
@@ -7,13 +7,13 @@ export function numberToOrdinal(num: number): string {
   const k = num % 100
 
   if (j === 1 && k !== 11) {
-    return `${num}st`
+    return `${num.toLocaleString()}st`
   }
   if (j == 2 && k != 12) {
-    return `${num}nd`
+    return `${num.toLocaleString()}nd`
   }
   if (j == 3 && k != 13) {
-    return `${num}rd`
+    return `${num.toLocaleString()}rd`
   }
-  return `${num}th`
+  return `${num.toLocaleString()}th`
 }


### PR DESCRIPTION
## Summary
Fixes for the following UI issues

**1 - Rank values are getting large, currently missing toLocaleString(). Also, need to truncate in the leaderboard row.**

<img width="262" alt="Screenshot 2022-05-25 at 22 46 35" src="https://user-images.githubusercontent.com/2752586/170372812-7410e2b0-6f3e-4bb7-a790-47cf8fb4d6d4.png"> to localeString()
<img width="233" alt="Screenshot 2022-05-25 at 22 46 44" src="https://user-images.githubusercontent.com/2752586/170372811-2e5f3a75-03b6-4c2c-ac69-13d48715e9e0.png">

**2- On the user page, when the graffiti is long, the container width is greater than the page width on small screens.**

<img width="250" alt="Screenshot 2022-05-25 at 22 49 55" src="https://user-images.githubusercontent.com/2752586/170373330-a487fc47-a094-4b52-9b57-04c584e6cbc6.png">

**3- On the user page, OffsetBorder Box can have height discrepancies in some cases. Also, reducing the font size to fit large numbers in box.**

<img width="250" alt="Screenshot 2022-05-25 at 22 52 45" src="https://user-images.githubusercontent.com/2752586/170373683-457cc818-bb87-47da-b0e6-bb5430488f32.png">



Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
