### PR TITLE
Add X-Frame-Options to headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,4 +2,15 @@ module.exports = {
   images: {
     domains: ['cdnjs.cloudflare.com'],
   },
+  headers: async () => [
+    {
+      source: '/:path*',
+      headers: [
+        {
+          key: 'X-Frame-Options',
+          value: 'SAMEORIGIN',
+        },
+      ],
+    },
+  ],
 }


### PR DESCRIPTION
## Summary

Added this header to the options so you cannot embed the website in an iframe preventing click jacking. Read more about this config option here, https://github.com/vercel/next.js/blob/a52bd712fe797b59cfd05ceaa4c33096a0c346ff/docs/api-reference/next.config.js/headers.md#headers

## Testing Plan
You can reproduce this by just putting this inside of a .html file and loading it when running the dev server, `<iframe src="http://localhost:3000"></iframe>`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
