### PR TITLE
fix: ironfish loading svg alignment

### DIFF
--- a/components/Loader/index.module.css
+++ b/components/Loader/index.module.css
@@ -6,8 +6,8 @@
 .ironfishLoader {
   background-color: black;
   clip-path: url(#fishclip);
-  width: 20rem;
-  height: 14rem;
+  width: 18rem;
+  height: 12rem;
   display: flex;
   margin: 0 auto;
   animation: float 3.5s infinite ease;
@@ -16,8 +16,6 @@
 .ironfishLoader::after {
   /* background-color: var(--ifm-color-secondary); */
   background-color: #FFA542;
-  height: 14rem;
-  width: 18rem;
   content: '';
   display: block;
   animation: swipe 3.5s infinite ease-in;


### PR DESCRIPTION
noticed that the ironfish loading svg is not centered properly.

<img width="335" alt="Screenshot 2022-06-23 at 22 54 27" src="https://user-images.githubusercontent.com/2752586/175422714-9fc5351a-17b5-4ef2-b763-57e633cb4ada.png">

