### PR TITLE
Make opening outside links in the new tab.

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -89,7 +89,7 @@ function Footer() {
             <span className="hidden md:inline">. All rights reserved.</span>
           </p>
           <div className="flex justify-between items-center w-40">
-            <a href="https://t.me/ironfishcryptochat">
+            <a href="https://t.me/ironfishcryptochat" target="_blank">
               <Image
                 src="/footer/telegram.svg"
                 layout="fixed"
@@ -98,7 +98,7 @@ function Footer() {
                 alt="Telegram"
               />
             </a>
-            <a href="https://github.com/iron-fish">
+            <a href="https://github.com/iron-fish" target="_blank">
               <Image
                 src="/footer/github.svg"
                 layout="fixed"
@@ -107,7 +107,7 @@ function Footer() {
                 alt="Github"
               />
             </a>
-            <a href="http://reddit.com/r/ironfish">
+            <a href="http://reddit.com/r/ironfish" target="_blank">
               <Image
                 src="/footer/reddit.svg"
                 layout="fixed"
@@ -116,7 +116,7 @@ function Footer() {
                 alt="Reddit"
               />
             </a>
-            <a href="https://twitter.com/ironfishcrypto">
+            <a href="https://twitter.com/ironfishcrypto" target="_blank">
               <Image
                 src="/footer/twitter.svg"
                 layout="fixed"
@@ -125,7 +125,7 @@ function Footer() {
                 alt="Twitter"
               />
             </a>
-            <a href="https://discord.gg/ironfish">
+            <a href="https://discord.gg/ironfish" target="_blank">
               <Image
                 src="/footer/discord.svg"
                 layout="fixed"

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -89,7 +89,11 @@ function Footer() {
             <span className="hidden md:inline">. All rights reserved.</span>
           </p>
           <div className="flex justify-between items-center w-40">
-            <a href="https://t.me/ironfishcryptochat" target="_blank">
+            <a
+              href="https://t.me/ironfishcryptochat"
+              target="_blank"
+              rel="noreferrer"
+            >
               <Image
                 src="/footer/telegram.svg"
                 layout="fixed"
@@ -98,7 +102,11 @@ function Footer() {
                 alt="Telegram"
               />
             </a>
-            <a href="https://github.com/iron-fish" target="_blank">
+            <a
+              href="https://github.com/iron-fish"
+              target="_blank"
+              rel="noreferrer"
+            >
               <Image
                 src="/footer/github.svg"
                 layout="fixed"
@@ -107,7 +115,11 @@ function Footer() {
                 alt="Github"
               />
             </a>
-            <a href="http://reddit.com/r/ironfish" target="_blank">
+            <a
+              href="http://reddit.com/r/ironfish"
+              target="_blank"
+              rel="noreferrer"
+            >
               <Image
                 src="/footer/reddit.svg"
                 layout="fixed"
@@ -116,7 +128,11 @@ function Footer() {
                 alt="Reddit"
               />
             </a>
-            <a href="https://twitter.com/ironfishcrypto" target="_blank">
+            <a
+              href="https://twitter.com/ironfishcrypto"
+              target="_blank"
+              rel="noreferrer"
+            >
               <Image
                 src="/footer/twitter.svg"
                 layout="fixed"
@@ -125,7 +141,11 @@ function Footer() {
                 alt="Twitter"
               />
             </a>
-            <a href="https://discord.gg/ironfish" target="_blank">
+            <a
+              href="https://discord.gg/ironfish"
+              target="_blank"
+              rel="noreferrer"
+            >
               <Image
                 src="/footer/discord.svg"
                 layout="fixed"


### PR DESCRIPTION
it is a good practice to open external links in a new tab. But currently, the links to social media in the footer are opening in the same tab. In this change added target="_blank" to make this small improvement.

## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
