### PR TITLE
Update EventRow.tsx

### DIFF
--- a/components/user/EventRow.tsx
+++ b/components/user/EventRow.tsx
@@ -98,7 +98,7 @@ const makeLinkForEvent = (type: EventType, metadata?: ApiEventMetadata) => {
     'block_hash' in metadata &&
     type === EventType.TRANSACTION_SENT
   ) {
-    return `https://explorer.ironfish.network/transaction/${metadata.transaction_hash}/${metadata.block_hash}`
+    return `https://explorer.ironfish.network/transaction/${metadata.transaction_hash}`
   }
   if ('hash' in metadata && type === EventType.BLOCK_MINED) {
     return `https://explorer.ironfish.network/blocks/${metadata.hash}`


### PR DESCRIPTION
Fix TxHash Link

## Summary

Link for Transaction return wrong value. Was fixed by Masternode24.de. Please add us some merge points =)

FAIL :
return `https://explorer.ironfish.network/transaction/${metadata.transaction_hash}/${metadata.block_hash}`
  
PASS : 
return `https://explorer.ironfish.network/transaction/${metadata.transaction_hash}`

![image](https://user-images.githubusercontent.com/81598429/179349315-db0c1244-a377-4bd6-b314-bb1889d7b078.png)

## Testing Plan

Just rebuild and open link

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
