### PR TITLE
Fix transaction URL leading to Explorer

### DIFF
--- a/components/user/EventRow.tsx
+++ b/components/user/EventRow.tsx
@@ -98,7 +98,7 @@ const makeLinkForEvent = (type: EventType, metadata?: ApiEventMetadata) => {
     'block_hash' in metadata &&
     type === EventType.TRANSACTION_SENT
   ) {
-    return `https://explorer.ironfish.network/transaction/${metadata.transaction_hash}/${metadata.block_hash}`
+    return `https://explorer.ironfish.network/transaction/${metadata.transaction_hash}`
   }
   if ('hash' in metadata && type === EventType.BLOCK_MINED) {
     return `https://explorer.ironfish.network/blocks/${metadata.hash}`


### PR DESCRIPTION
## Summary

On the leaderboard's User page, link of the successfully processed transaction was leading to a 404 page on Explorer (e.g. https://explorer.ironfish.network/transaction/1d2c2a8ad5b0194381d7086d88e9b43a30548c7cde1cdfbaf97792213f098720/000000000009668ee2c696ae3aefe1fba9524d6cf7350dee37bbb784fb461c34) 

Fixed by removing the last part of URL (block hash)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
```
- [ ] Yes
- [x] No
```