### PR TITLE
Fix profile not using user total points

### DIFF
--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -182,10 +182,6 @@ export default function User({ showNotification, loginContext }: Props) {
   const endDate = nextMondayFrom(nextMonday(new Date()))
   const joinedOn = formatUTC($user.created_at, `'Joined' MMMM do',' y`)
 
-  const phase2Points =
-    $allTimeMetrics.metrics.node_uptime.points +
-    $allTimeMetrics.metrics.send_transaction.points
-
   const tweetText = `Iron Fish Incentivized Testnet: ${
     $user.graffiti
   } - ${$user.total_points.toLocaleString()} total points! #ironfish https://testnet.ironfish.network/users/${userId}`
@@ -331,7 +327,7 @@ export default function User({ showNotification, loginContext }: Props) {
                   <LabeledStat label="Phase 2 Rank" value={ordinalRank} />
                   <LabeledStat
                     label="Phase 2 Points"
-                    value={phase2Points.toLocaleString()}
+                    value={$user.total_points.toLocaleString()}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary

It was counting up individual categories and missing some, instead of
using the users total points.

**Broken**
![Screen Shot 2022-07-26 at 1 01 18 PM](https://user-images.githubusercontent.com/458976/181066796-d675c4a7-5294-4d4f-a85e-c68502494af5.png)

**Fixed**
![Screen Shot 2022-07-26 at 1 01 37 PM](https://user-images.githubusercontent.com/458976/181066799-d20b734c-c6f6-4b1b-bd38-b01b5f47800e.png)


## Testing Plan
Run and look at points for a user that has pull request points

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
