### PR TITLE
Fix rank text overflow

### DIFF
--- a/components/leaderboard/LeaderboardRow.tsx
+++ b/components/leaderboard/LeaderboardRow.tsx
@@ -111,7 +111,8 @@ function LeaderboardRow({ rank, graffiti, points = 0 }: Props) {
           'font-extended',
           'text-2xl',
           'w-16',
-          'sm:w-24'
+          'sm:w-24',
+          'truncate'
         )}
       >
         {rankStr}


### PR DESCRIPTION
## Summary
Fix https://github.com/iron-fish/website-testnet/issues/282. Adding ellipsis so text doesn't overflow.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
