### PR TITLE
fix: retroactively update rewards cards

### DIFF
--- a/components/About/data.tsx
+++ b/components/About/data.tsx
@@ -58,7 +58,7 @@ export const guidelines = {
     {
       title: 'Rewards',
       content:
-        'The Incentivized Testnet program will distribute up to 420,000 (1% of the initial supply) Iron Fish tokens to eligible participants, proportional to your Leaderboard points. Token distribution may be canceled at any time due to regulatory concerns. We may at any time amend or eliminate Leaderboard points.',
+        'The Incentivized Testnet program will distribute Iron Fish tokens to eligible participants, proportional to your Leaderboard points. Token distribution may be canceled at any time due to regulatory concerns. We may at any time amend or eliminate Leaderboard points. Rewards for code contributions will grant points in a separate competition pool relative to miners.',
       behind: 'bg-white',
     },
     {


### PR DESCRIPTION
## Summary
Updates rewards card to retroactively:
1) Remove explicit token conversion rate to adhere to legal guidance.
2) Describe second code contribution point pool for those who contributed during phase 1.
## Testing Plan
# BEFORE

<img width="577" alt="Screen Shot 2022-10-31 at 10 15 07 AM" src="https://user-images.githubusercontent.com/26990067/199068764-42ee36ca-c032-4707-b991-5e1e9762cdef.png">


# AFTER

<img width="638" alt="Screen Shot 2022-10-31 at 9 19 06 AM" src="https://user-images.githubusercontent.com/26990067/199057364-bbe1dd1b-dc5f-4b17-a24b-c3d9deee2f07.png">



## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
