### PR TITLE
fix: retroactive changes for tokens and pools

### DIFF
--- a/components/About/Phase.tsx
+++ b/components/About/Phase.tsx
@@ -3,13 +3,13 @@ import clsx from 'clsx'
 import Link from 'next/link'
 import OffsetBox from 'components/OffsetBorder/Box'
 import CheckIcon from 'components/icons/Check'
-import { capitalDigit } from 'utils/number-to-words'
 
 import { Status } from './types'
 
 export type Pool = {
   size: number
   categories: string[]
+  poolNum?: number
 }
 
 export type PhaseProps = {
@@ -53,11 +53,7 @@ export const Phase = ({
         >
           Phase {index}
         </h4>
-        <p className={clsx('my-2', 'text-left', 'w-full', 'text-lg')}>
-          {capitalDigit(pools.length)} prize{' '}
-          {pools.length === 1 ? 'pool' : 'pools'} totalling{' '}
-          {cumulativePoolSize(pools)} coins
-        </p>
+        <p className={clsx('my-2', 'text-left', 'w-full', 'text-lg')}></p>
         <p className={clsx('text-left', 'w-full')}>{summary}</p>
         <Link href={isComplete ? '#' : '/signup'} passHref>
           <a
@@ -94,12 +90,12 @@ export const Phase = ({
             )}
           </a>
         </Link>
-        {pools.map(({ size, categories }: Pool, i: number) => (
+        {pools.map(({ size, categories, poolNum }: Pool, i: number) => (
           <div
             key={`${size}-${categories.length}`}
             className={clsx('mt-6', 'w-full', 'text-left')}
           >
-            Prize pool {i + 1}: {size.toLocaleString()} coins
+            Prize pool {poolNum || i + 1}:
             <ul className="pl-5">
               {categories.map((category: string) => (
                 <li key={category} className={clsx('list-disc', 'pt-2')}>

--- a/components/About/data.tsx
+++ b/components/About/data.tsx
@@ -59,7 +59,7 @@ export const guidelines = {
     {
       title: 'Rewards',
       content:
-        'The Incentivized Testnet program will distribute up to 420,000 (1% of the initial supply) Iron Fish tokens to eligible participants, proportional to your Leaderboard points. Token distribution may be canceled at any time due to regulatory concerns. We may at any time amend or eliminate Leaderboard points.',
+        'The Incentivized Testnet program will distribute Iron Fish tokens to eligible participants, proportional to your Leaderboard points. Token distribution may be canceled at any time due to regulatory concerns. We may at any time amend or eliminate Leaderboard points. Rewards for code contributions will grant points in a separate competition pool relative to miners.',
       behind: 'bg-white',
     },
     {
@@ -183,12 +183,17 @@ export const phases = [
     pools: [
       {
         size: 42e4,
+        poolNum: 1,
         categories: [
           'Mining Blocks',
           'Finding Bugs',
-          'Submitting Pull Requests',
           'Community Contributions',
         ],
+      },
+      {
+        size: 42e4,
+        poolNum: 3,
+        categories: ['Submitting Pull Requests'],
       },
     ],
   },
@@ -198,9 +203,10 @@ export const phases = [
     pools: [
       {
         size: 21e4,
+        poolNum: 2,
         categories: ['Hosting a Node', 'Finding Bugs', 'Sending Transactions'],
       },
-      { size: 105e3, categories: ['Submitting Pull Requests'] },
+      { size: 105e3, poolNum: 3, categories: ['Submitting Pull Requests'] },
     ],
   },
 ]


### PR DESCRIPTION
## Summary
Remove explicit references to coins in accordance with legal guidance.

Split out points for code contributors and pools. 

Pool 3 will retroactively apply for all code contributions during Phase 1 and Phase 2.
## Testing Plan

# BEFORE 
<img width="1122" alt="Screen Shot 2022-10-31 at 10 15 13 AM" src="https://user-images.githubusercontent.com/26990067/199068604-a708ebb3-420c-4893-97a6-27ace7a4abc6.png">


# AFTER
<img width="1129" alt="Screen Shot 2022-10-31 at 9 41 18 AM" src="https://user-images.githubusercontent.com/26990067/199063437-b053db6d-e06b-44df-8edf-4880690c2a8e.png">

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
