### PR TITLE
Redirect to the leaderboard when requests time out

### DIFF
--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -118,7 +118,12 @@ export default function User({ showNotification, loginContext }: Props) {
         // eslint-disable-next-line no-console
         console.warn(e)
 
-        throw e
+        Router.push(
+          `/leaderboard?toast=${btoa(
+            'An error occurred while fetching user data'
+          )}`
+        )
+        return
       }
     }
 


### PR DESCRIPTION
## Summary

The user page perma-loads even after requests time out. We may as well redirect to the leaderboard rather than leaving the page stuck there forever not doing anything.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
