### PR TITLE
feat: add countdown timer for end of phase 2

### DIFF
--- a/components/PageBanner/index.tsx
+++ b/components/PageBanner/index.tsx
@@ -29,7 +29,7 @@ export const PageBanner: FC<PageBannerProps> = ({
           'text-4xl',
           // 'w-3/5',
           'mx-[12.5%]',
-          'mt-24',
+          'mt-8',
           'mb-8',
           'font-extended',
           'md:mx-4',

--- a/components/leaderboard/CountdownTimer.tsx
+++ b/components/leaderboard/CountdownTimer.tsx
@@ -4,6 +4,7 @@ import { intervalToDuration } from 'date-fns'
 import type { Duration } from 'date-fns'
 
 import { formatEventDate } from 'utils/events'
+import clsx from 'clsx'
 
 const customFormatDuration = (x: Duration) =>
   `${x.days ? x.days + 'd : ' : ''}${x.hours ? x.hours + 'hr : ' : ''}${
@@ -32,13 +33,13 @@ const CountdownTimer = (props: CountdownTimerProps) => {
         behind="bg-white"
         rounded
         size="2"
-        className="w-[18.25rem]"
+        className={clsx('w-[18.25rem]', 'mt-4')}
         background="bg-ifpink"
       >
         <div className="w-[18.25rem] px-4 py-2 m-auto">
           <div className="flex flex-col justify-center items-center">
             <span className="text-lg">{customFormatDuration(ii)}</span>
-            <span className="uppercase text-sm text-ifmauve">{event}</span>
+            <span className="uppercase text-sm">{event}</span>
           </div>
         </div>
       </CustomBox>

--- a/components/leaderboard/CountdownTimer.tsx
+++ b/components/leaderboard/CountdownTimer.tsx
@@ -3,7 +3,6 @@ import { CustomBox } from 'components/OffsetBorder'
 import { intervalToDuration } from 'date-fns'
 import type { Duration } from 'date-fns'
 
-import { nextMondayFrom } from 'utils/date'
 import { formatEventDate } from 'utils/events'
 
 const customFormatDuration = (x: Duration) =>
@@ -11,10 +10,14 @@ const customFormatDuration = (x: Duration) =>
     x.minutes ? x.minutes + 'min : ' : ''
   }${x.seconds ? x.seconds + 'sec' : '0sec'}`
 
-const CountdownTimer = () => {
+type CountdownTimerProps = {
+  end: Date
+  event: string
+}
+const CountdownTimer = (props: CountdownTimerProps) => {
+  const { end, event } = props
   const now = new Date()
   const [$time, $setTime] = useState(now)
-  const end = nextMondayFrom(now)
   useEffect(() => {
     const i = setInterval(() => $setTime(new Date()), 1000)
     return () => clearInterval(i)
@@ -35,9 +38,7 @@ const CountdownTimer = () => {
         <div className="w-[18.25rem] px-4 py-2 m-auto">
           <div className="flex flex-col justify-center items-center">
             <span className="text-lg">{customFormatDuration(ii)}</span>
-            <span className="uppercase text-sm text-ifmauve">
-              Until Weekly Rollover
-            </span>
+            <span className="uppercase text-sm text-ifmauve">{event}</span>
           </div>
         </div>
       </CustomBox>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -23,6 +23,7 @@ import { useResponsiveCards } from 'components/About/hooks'
 import Loader from 'components/Loader'
 
 import { ArrowLeft, ArrowRight } from 'components/icons/Arrows'
+import CountdownTimer from 'components/leaderboard/CountdownTimer'
 
 type ArrowButtonProps = {
   children: ReactNode
@@ -96,6 +97,10 @@ export default function About({ showNotification, loginContext }: AboutProps) {
           'flex-col'
         )}
       >
+        <CountdownTimer
+          end={new Date(2022, 11, 15)}
+          event=" until end of Phase 2."
+        />
         <PageBanner
           title={
             <>

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -14,6 +14,7 @@ import QuestionAnswer from 'components/FAQ/QuestionAnswer'
 import Loader from 'components/Loader'
 import { scrollTo } from 'utils/scroll'
 import { LoginContext } from 'hooks/useLogin'
+import CountdownTimer from 'components/leaderboard/CountdownTimer'
 
 const questions: ReadonlyArray<{
   question: string
@@ -277,6 +278,10 @@ export default function Faq({ showNotification, loginContext }: FaqProps) {
           'flex-col'
         )}
       >
+        <CountdownTimer
+          end={new Date(2022, 11, 15)}
+          event=" until end of Phase 2."
+        />
         <PageBanner
           title="Testnet FAQ"
           text={<PageBannerBody />}

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -24,6 +24,7 @@ import { useQueriedToast } from 'hooks/useToast'
 import { usePaginatedUsers } from 'hooks/usePaginatedUsers'
 
 import * as API from 'apiClient'
+import CountdownTimer from 'components/leaderboard/CountdownTimer'
 
 type Props = {
   showNotification: boolean
@@ -158,6 +159,10 @@ export default function Leaderboard({ showNotification, loginContext }: Props) {
           'flex-col'
         )}
       >
+        <CountdownTimer
+          end={new Date(2022, 11, 15)}
+          event=" until end of Phase 2."
+        />
         <PageBanner
           title={
             <>


### PR DESCRIPTION
## Summary
<img width="1334" alt="Screen Shot 2022-11-04 at 3 23 45 PM" src="https://user-images.githubusercontent.com/26990067/200083640-fbd9b7f2-2455-42bd-b914-cfddb091689b.png">
<img width="1246" alt="Screen Shot 2022-11-07 at 9 39 25 AM" src="https://user-images.githubusercontent.com/26990067/200377899-b9b3f64f-9ef0-4893-8fc8-6eb937d81e67.png">
<img width="1273" alt="Screen Shot 2022-11-07 at 9 39 21 AM" src="https://user-images.githubusercontent.com/26990067/200377905-c8e66622-2ff9-4b6d-9e53-d12263c497e4.png">



## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
