### PR TITLE
Fix deprecated description on About page

### DIFF
--- a/components/About/data.tsx
+++ b/components/About/data.tsx
@@ -59,7 +59,7 @@ export const guidelines = {
     {
       title: 'Rewards',
       content:
-        'The Incentivized Testnet program will distribute up to 420,000 (1% of the initial supply) Iron Fish tokens to eligible participants, proportional to your Leaderboard points. Token distribution may be canceled at any time due to regulatory concerns. We may at any time amend or eliminate Leaderboard points.',
+        'The Incentivized Testnet program will distribute up to 735,000 (1.75% of the initial supply) Iron Fish tokens to eligible participants, proportional to your Leaderboard points. Token distribution may be canceled at any time due to regulatory concerns. We may at any time amend or eliminate Leaderboard points.',
       behind: 'bg-white',
     },
     {


### PR DESCRIPTION
On "About" page we have a deprecated description for "Rewards" section. The text is wrong because it does not include rewards for Phase 2. The right data are:
The Incentivized Testnet program will distribute up to 735,000 (1.75% of the initial supply) Iron Fish tokens to eligible participants, proportional to your Leaderboard points. Token distribution may be canceled at any time due to regulatory concerns. We may at any time amend or eliminate Leaderboard points.

Before:
![image](https://user-images.githubusercontent.com/29353655/200128759-2610a048-3a30-4e92-9036-2fd465e45fab.png)

After:
![image](https://user-images.githubusercontent.com/29353655/200128775-55efe97a-d92f-4e31-bc80-02ba61c8209f.png)


## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
