### PR TITLE
Fix "Phase 1" points distribution text.

### DIFF
--- a/components/About/CallToAction.tsx
+++ b/components/About/CallToAction.tsx
@@ -14,6 +14,7 @@ type CTAProps = {
   ctaText?: string
   href?: string
   comingSoon?: boolean
+  ended?: boolean
   submissionForm?: boolean
 }
 
@@ -26,6 +27,7 @@ export const CallToAction = ({
   href,
   ctaText,
   comingSoon = false,
+  ended = false,
   submissionForm = false,
 }: CTAProps) => {
   const button = ctaText ? (
@@ -46,7 +48,14 @@ export const CallToAction = ({
               Coming soon!
             </div>
           )}
-          {!comingSoon && <strong className="uppercase text-lg">{kind}</strong>}
+          {ended && (
+            <div className="bg-iflightgray text-ifgray px-4 py-2 inline-block mt-2 text-xs md:text-md mb-2">
+              Phase 1 Ended
+            </div>
+          )}
+          {!comingSoon && !ended && (
+            <strong className="uppercase text-lg">{kind}</strong>
+          )}
           <h3 className="text-left text-4xl mt-3 mb-4 font-extended">
             {title}
           </h3>
@@ -60,30 +69,31 @@ export const CallToAction = ({
               ))}
             </ul>
           )}
-          {earn > 0 && !comingSoon && (
+          {earn > 0 && !comingSoon && !ended && (
             <div className="bg-ifpink px-4 py-2 inline-block mt-2 text-xs md:text-md">
               Earn up to {earn.toLocaleString('en-US')} points a week
             </div>
           )}
           <div className="mb-8" />
-          {ctaText && href && button ? (
-            <Link href={href}>{button}</Link>
-          ) : (
-            button
-          )}
-          {submissionForm && (
-            <Link href="https://forms.gle/yrAtzoyKTwLgLTRZA" passHref>
-              <RawButton
-                border="border"
-                className="m-auto w-full mt-2 max-w-md mb-2 text-md p-2"
-                colorClassName="text-black bg-transparent hover:bg-black hover:text-white"
-              >
-                <Link href={'https://forms.gle/yrAtzoyKTwLgLTRZA'}>
-                  Claim Points
-                </Link>
-              </RawButton>
-            </Link>
-          )}
+          {!ended &&
+            (ctaText && href && button ? (
+              <Link href={href}>{button}</Link>
+            ) : (
+              button
+            )) &&
+            submissionForm && (
+              <Link href="https://forms.gle/yrAtzoyKTwLgLTRZA" passHref>
+                <RawButton
+                  border="border"
+                  className="m-auto w-full mt-2 max-w-md mb-2 text-md p-2"
+                  colorClassName="text-black bg-transparent hover:bg-black hover:text-white"
+                >
+                  <Link href={'https://forms.gle/yrAtzoyKTwLgLTRZA'}>
+                    Claim Points
+                  </Link>
+                </RawButton>
+              </Link>
+            )}
         </div>
       </Box>
     </div>

--- a/components/About/data.tsx
+++ b/components/About/data.tsx
@@ -104,11 +104,13 @@ export const callsToAction = {
         'If you found a bug in the Iron Fish full node implementation, please submit it as an issue. Issues are reviewed by the core development team on a rolling basis and awarded by the end of the week. The issue will be accepted if it’s a legitimate bug and not a duplicate of an existing issue. Fill out the form to claim your points after submitting an issue.',
       points: ['1 bug = 100 points'],
       ctaText: 'Submit an issue ',
+      ended: true,
       href: 'https://github.com/iron-fish/ironfish/issues',
       submissionForm: true,
     },
     {
       title: 'Contributing to the Community',
+      ended: true,
       content: (
         <>
           Help us make Iron Fish more accessible to a wider audience! Published
@@ -138,6 +140,7 @@ export const callsToAction = {
         'Sometimes the community does something amazing that doesn’t fall under any of these categories. Email us at testnet@ironfish.network with your Iron Fish graffiti and let us know about it!',
       earn: 0,
       ctaText: 'Email us',
+      ended: true,
       href: 'mailto:testnet@ironfish.network',
     },
   ],
@@ -148,10 +151,12 @@ export const callsToAction = {
         'Once you sign up for the incentivized testnet, actively mining automatically earns you points for blocks that are mined and accepted to the main chain.',
       points: ['1 block = 100 points'],
       ctaText: 'Get started with mining',
+      ended: true,
       href: 'https://ironfish.network/docs/onboarding/miner-iron-fish',
     },
     {
       title: 'Promoting the Testnet',
+      ended: true,
       content: (
         <>
           Quality tweets, videos, podcasts, vlogs, poems, TikToks, you name it;
@@ -186,6 +191,7 @@ export const callsToAction = {
         'Large = 1000 points',
       ],
       ctaText: 'Submit a PR',
+      ended: true,
       href: 'https://github.com/iron-fish/ironfish/pulls',
       submissionForm: true,
     },
@@ -195,6 +201,7 @@ export const callsToAction = {
       content:
         'Let us know if you have suggestions for other categories we should add!',
       ctaText: 'Reach out on Discord',
+      ended: true,
       href: 'https://discord.gg/ironfish',
       earn: 0,
       kind: 'coming soon',

--- a/components/About/data.tsx
+++ b/components/About/data.tsx
@@ -187,7 +187,7 @@ export const callsToAction = {
       earn: 5000,
       points: [
         'Small = 250 points',
-        'Medium = 750 points',
+        'Medium = 500 points',
         'Large = 1000 points',
       ],
       ctaText: 'Submit a PR',

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -94,7 +94,7 @@ export default function About({ loginContext }: AboutProps) {
       >
         <PageBanner
           title="About the Incentivized Testnet"
-          text="Sign up for the Iron Fish incentivized testnet to help make Iron Fish great 💖. Participate to earn testnet points (see Testnet Guidelines below for more details)."
+          text="Phase 1 of the Incentivized Testnet has now ended. Sign up below for Phase 2 (starting date is TBD)."
           buttonText={!loaded ? 'Sign Up' : ''}
           buttonClassName={clsx(
             'm-auto',

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -117,6 +117,7 @@ export default function Leaderboard({ loginContext }: Props) {
 
   const { checkLoggedIn, checkLoading } = loginContext
   const isLoggedIn = checkLoggedIn()
+  const ended = true
   const isLoading = checkLoading()
 
   const { fetchPrevious, fetchNext, $hasPrevious, $hasNext } =
@@ -171,7 +172,7 @@ export default function Leaderboard({ loginContext }: Props) {
             'md:px-4'
           )}
         >
-          {isLoggedIn && <CountdownTimer />}
+          {isLoggedIn && !ended && <CountdownTimer />}
         </PageBanner>
         <div className={clsx('w-4/5', 'md:w-2/3')}>
           <div className={clsx('flex', 'flex-col', 'flex-wrap', 'md:flex-row')}>


### PR DESCRIPTION
## Summary

According to that "Prize pool 3" spans all phases there should be the same points depending on PR size.
But we see that in phase 1 Medium PR cost 750 points while in phase 2 it is 500 points.
Phase 1
![image](https://user-images.githubusercontent.com/29353655/201139791-64d5540d-3e6a-492d-88c6-77f68d137e25.png)

Phase 2
![image](https://user-images.githubusercontent.com/29353655/201139901-c114f82e-c1bb-4f1e-beb1-6b08ede575d4.png)

We expect that PR cost should be the same for both phases. Also required changes in the backend. Because as I see the API returns 750 points for medium PR.


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
