### PR TITLE
Input outline styling improved

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -155,4 +155,5 @@ a {
 * {
   box-sizing: border-box;
 }
+
 input{ outline: none;}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -155,3 +155,4 @@ a {
 * {
   box-sizing: border-box;
 }
+input{ outline: none;}


### PR DESCRIPTION
## Summary
Input outline styling improved

This was the earlier design:
![2022-11-20_07h37_14](https://user-images.githubusercontent.com/38426196/202879416-cfe68610-2d23-4e28-a41a-4c72e9109482.png)

After this change it'll look like this:
![improved](https://user-images.githubusercontent.com/38426196/202879496-17cb87ec-a812-431b-9120-2cc8620f8992.png)


Pr screencast:
 [Desktop](https://drive.google.com/file/d/1NhgV3lfAAThTxuAGnBW5pl588CExce0p/view?usp=sharing)
 [Mobile](https://drive.google.com/file/d/1vp5EKJ6y1xibTnSsBmjrpugdx_YemauD/view?usp=sharing)

Production screencast:
 [Desktop](https://drive.google.com/file/d/1UgiRQzmi5j7Z2o-W3Qu8808UitpbBigD/view?usp=sharing)


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
