### PR TITLE
Clamp countdown to end time

### DIFF
--- a/components/leaderboard/CountdownTimer.tsx
+++ b/components/leaderboard/CountdownTimer.tsx
@@ -17,13 +17,20 @@ type CountdownTimerProps = {
 }
 const CountdownTimer = (props: CountdownTimerProps) => {
   const { end, event } = props
+
   const now = new Date()
-  const [$time, $setTime] = useState(now)
+  const [$time, $setTime] = useState(now < end ? now : end)
+
   useEffect(() => {
-    const i = setInterval(() => $setTime(new Date()), 1000)
+    const i = setInterval(() => {
+      const update = new Date()
+      $setTime(update < end ? update : end)
+    }, 1000)
     return () => clearInterval(i)
   }, [])
-  const ii = intervalToDuration({ start: $time > end ? end : $time, end: end })
+
+  const ii = intervalToDuration({ start: $time, end: end })
+
   return (
     <div
       className="w-full flex flex-col justify-center items-center text-center"

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -98,8 +98,8 @@ export default function About({ showNotification, loginContext }: AboutProps) {
         )}
       >
         <CountdownTimer
-          end={new Date(1703782800000)}
-          event=" until deposits are closed."
+          end={new Date(1669661485913)}
+          event=" until Phase 2 is closed."
         />
         <PageBanner
           title={

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -279,8 +279,8 @@ export default function Faq({ showNotification, loginContext }: FaqProps) {
         )}
       >
         <CountdownTimer
-          end={new Date(1703782800000)}
-          event=" until deposits are closed."
+          end={new Date(1669661485913)}
+          event=" until Phase 2 is closed."
         />
         <PageBanner
           title="Testnet FAQ"

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -160,8 +160,8 @@ export default function Leaderboard({ showNotification, loginContext }: Props) {
         )}
       >
         <CountdownTimer
-          end={new Date(1703782800000)}
-          event=" until deposits are closed."
+          end={new Date(1669661485913)}
+          event=" until Phase 2 is closed."
         />
         <PageBanner
           title={


### PR DESCRIPTION
## Summary

This will clamp the countdown to the end time.

<img width="387" alt="Screen Shot 2022-11-28 at 2 00 58 PM" src="https://user-images.githubusercontent.com/458976/204359251-bd5a6303-a592-4a0e-935d-2c98e91150fe.png">

## Testing Plan

Looked at it locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
