### PR TITLE
Fixed crash while open user stats

### DIFF
--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -165,7 +165,7 @@ export default function User({ showNotification, loginContext }: Props) {
     ? numberToOrdinal($allTimeMetrics.pools.main.rank)
     : 'NA'
 
-  const phase3Points = $allTimeMetrics.pools.main.points
+  const phase3Points = $allTimeMetrics.pools.main.points || 0
 
   const startDate = new Date(2023, 18, 1)
   const endDate = nextMondayFrom(


### PR DESCRIPTION
## Summary

We have an error when opening the user metrics page.
```
TypeError: Cannot read properties of null (reading 'toLocaleString')
    at De ([id]-21bb4c7fe40e7902.js:1:49840)
```
![image](https://user-images.githubusercontent.com/29353655/211156159-386e3ab0-0e34-4e41-851b-1f5803cca6ad.png)
![image](https://user-images.githubusercontent.com/29353655/211156178-779db90b-bee2-4c98-9a55-3d92a37e212a.png)

This change is a fix for this problem.

AFTER FIX:
![image](https://user-images.githubusercontent.com/29353655/211156263-44e988e8-17c3-4e4f-9e5b-fc8c741b3530.png)



## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
