### PR TITLE
Remove deplicated category pull-requests in options

### DIFF
--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -54,7 +54,6 @@ const FIELDS = {
       { name: 'Pool 3', value: API.EventType.PULL_REQUEST_MERGED },
       { name: 'Hosting a Node', value: API.EventType.NODE_HOSTED },
       { name: 'Bugs Found', value: API.EventType.BUG_CAUGHT },
-      { name: 'Pull Requests', value: API.EventType.PULL_REQUEST_MERGED },
       { name: 'Multi-Asset Mint', value: API.EventType.MULTI_ASSET_MINT },
       { name: 'Multi-Asset Burn', value: API.EventType.MULTI_ASSET_BURN },
       {


### PR DESCRIPTION
## Summary
We use Pool3 for pull request points, so this "pull requests" category is duplicated, remove it.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
