### PR TITLE
Fix FAQ and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 Create an `.env.local` file. You can copy the existing template (`cp .env.template .env.local`)
 
 ```
-NEXT_PUBLIC_API_URL=https://api.ironfish.network
-API_URL=https://api.ironfish.network
+NEXT_PUBLIC_API_URL=https://api-staging.ironfish.network
 NEXT_PUBLIC_MAGIC_PUBLISHABLE_KEY=test
+NEXT_PUBLIC_LOCAL_USER=true
 ```
 
 Then, run the development server:

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -75,7 +75,7 @@ const questions: ReadonlyArray<{
     id: `how-to-mint`,
     answer: (
       <div>
-        You can burn an asset by running <pre>ironfish wallet:mint</pre>
+        You can mint an asset by running <pre>ironfish wallet:mint</pre>
       </div>
     ),
   },
@@ -93,7 +93,7 @@ const questions: ReadonlyArray<{
     id: `how-to-send`,
     answer: (
       <div>
-        You can burn an asset by running <pre>ironfish wallet:send</pre>
+        You can send an asset by running <pre>ironfish wallet:send</pre>
       </div>
     ),
   },


### PR DESCRIPTION
1 - update README env to be same as `.env.template` file
2 - FAQ has some typos. shouldn't be `burn` everywhere.

<img width="600" alt="Screenshot 2023-01-17 at 16 56 15" src="https://user-images.githubusercontent.com/2752586/212947012-0463f8fc-a2dd-4414-9b84-c849d856e0c2.png">

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
