### PR TITLE
Change start time to january 18th

### DIFF
--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -167,7 +167,7 @@ export default function User({ showNotification, loginContext }: Props) {
 
   const phase3Points = $allTimeMetrics.pools.main.points || 0
 
-  const startDate = new Date(2023, 18, 1)
+  const startDate = new Date(2023, 0, 18)
   const endDate = nextMondayFrom(
     nextMonday(new Date() < startDate ? startDate : new Date())
   )


### PR DESCRIPTION
## Summary
This date was invalid because it had the 18th month of 2023.

*Before*
![Screen Shot 2023-01-18 at 4 03 10 PM](https://user-images.githubusercontent.com/458976/213294192-66eadd10-2cce-4c53-88c7-db9fb12935f2.png)

*After*
![Screen Shot 2023-01-18 at 4 03 13 PM](https://user-images.githubusercontent.com/458976/213294075-69c6278c-3c06-4d55-8a1c-a3b6b2c03169.png)

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
