### PR TITLE
Fix link for events from phase3

### DIFF
--- a/components/user/EventRow.tsx
+++ b/components/user/EventRow.tsx
@@ -101,11 +101,17 @@ export type EventRowProps = {
 }
 
 const makeLinkForEvent = (type: EventType, metadata?: ApiEventMetadata) => {
+  const EVENTS_WITH_TRANSACTIONS = [
+    EventType.TRANSACTION_SENT,
+    EventType.MULTI_ASSET_BURN,
+    EventType.MULTI_ASSET_MINT,
+    EventType.MULTI_ASSET_TRANSFER,
+  ]
   if (!metadata) return ''
   if (
     'transaction_hash' in metadata &&
     'block_hash' in metadata &&
-    type === EventType.TRANSACTION_SENT
+    EVENTS_WITH_TRANSACTIONS.includes(type)
   ) {
     return `https://explorer.ironfish.network/transaction/${metadata.transaction_hash}`
   }


### PR DESCRIPTION
## Summary
We have an issue with links to explorer for MINT|BURN|SENT events.
Current result:
We cannot navigate to explorer. We only can copy transaction hash.

After fix:
The links are clickable and we can navigate to the explorer
![image](https://user-images.githubusercontent.com/29353655/213537130-a415487c-101f-403e-af2e-c49794dfe56e.png)
 And after clicking we see our transaction in explorer
![image](https://user-images.githubusercontent.com/29353655/213537364-96aff89e-84c9-42f2-89e8-ba1611889369.png)


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
