### PR TITLE
Changed SNAKE_CASE text to regular like it done for other categories

### DIFF
--- a/components/user/EventRow.tsx
+++ b/components/user/EventRow.tsx
@@ -61,6 +61,12 @@ export function displayEventType(type: EventType): IconText {
         <>Hosted a node</>
       ) : type === EventType.TRANSACTION_SENT ? (
         <>Transaction Sent</>
+      ) : type === EventType.MULTI_ASSET_BURN ? (
+        <>Multi-Asset Burn</>
+      ) : type === EventType.MULTI_ASSET_TRANSFER ? (
+        <>Multi-Asset Send</>
+      ) : type === EventType.MULTI_ASSET_MINT ? (
+        <>Multi-Asset Mint</>
       ) : (
         type
       )}


### PR DESCRIPTION
## Summary
In the "activity" table we have snake_case for new activities while based on previous phases looks like it should be regular text


### AFTER FIX:
![image](https://user-images.githubusercontent.com/29353655/213542717-e0dd40da-7148-4264-a3e1-9c3d0bc94fb5.png)

### BEFORE FIX:
![image](https://user-images.githubusercontent.com/29353655/213543211-f0f136a2-aa2d-447a-95e8-72e3f57c465f.png)


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
