### PR TITLE
fix: increase leaderboard search from 300 to 500

### DIFF
--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -86,7 +86,7 @@ export default function Leaderboard({ showNotification, loginContext }: Props) {
 
   // Search field hooks
   const [$search, $setSearch] = useState('')
-  const $debouncedSearch = useDebounce($search, 300)
+  const $debouncedSearch = useDebounce($search, 500)
   const [$searching, $setSearching] = useState(false)
   const countryValue = $country?.value
   const eventTypeValue = $eventType?.value


### PR DESCRIPTION
## Summary

The 300 is a little aggressive, I often find it searching before I've finished typing unless I know exactly what I'm typing.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
