### PR TITLE
Expired Discord link on Testnet website

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -142,7 +142,7 @@ function Footer() {
               />
             </a>
             <a
-              href="https://discord.gg/ironfish"
+              href="https://discord.ironfish.network/"
               target="_blank"
               rel="noreferrer"
             >


### PR DESCRIPTION
I have found an issue on the testnet website where the displayed Discord social media link is expired. I strongly recommend using the updated URL, https://discord.ironfish.network/. Please fix this issue as soon as possible to avoid any inconvenience for users who want to join ironfish community.

![Screenshot 2023-01-21 201022](https://user-images.githubusercontent.com/59562911/213867460-96ff20d4-4661-4670-b184-1a90ca6e9218.png)
