### PR TITLE
fix: weekly display bug on sunday instead of monday

### DIFF
--- a/utils/date.ts
+++ b/utils/date.ts
@@ -10,7 +10,7 @@ export const makeRelativeConverter = () => {
 }
 
 export const weeksBetween = (start: Date, end: Date) => {
-  const raw = eachWeekOfInterval({ start, end }, { weekStartsOn: 1 })
+  const raw = eachWeekOfInterval({ start, end }, { weekStartsOn: 0 })
   const convert = makeRelativeConverter()
   return raw.map(convert)
 }


### PR DESCRIPTION
## Summary
Was previously set to Monday, which doesn't align with api code here:
https://github.com/iron-fish/ironfish-api/blob/b422faae9fcef8df5fbba97b1b961fec407cb4b4/src/users/utils/week.ts#L6
Updating to match.
## Testing Plan
<img width="1258" alt="Screen Shot 2023-01-23 at 9 33 37 AM" src="https://user-images.githubusercontent.com/26990067/214109513-d53f9878-09cc-4bf9-bf37-b267b7ba0327.png">
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.


```
[ ] Yes
```
