### PR TITLE
updates testnet website info on uptime points

### DIFF
--- a/components/About/data.tsx
+++ b/components/About/data.tsx
@@ -136,8 +136,15 @@ export const callsToAction = {
     },
     {
       title: 'Hosting a node',
-      content:
-        'You can earn points by hosting an Iron Fish full node. To do so, make sure your telemetry is turned on, and your graffiti is set. You will only be rewarded points for hosting one node per graffiti.',
+      content: (
+        <>
+          You can earn points by hosting an Iron Fish full node. To do so, make
+          sure your telemetry is turned on and your graffiti is set. You must
+          update your node within one week after a new version in order to earn
+          points for hosting a node. You will only be rewarded points for
+          hosting one node per graffiti.
+        </>
+      ),
       points: ['12 hours of continuous uptime = 10 points'],
       status: Status.Active,
       ctaText: 'Set up instructions',

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -130,7 +130,13 @@ const questions: ReadonlyArray<{
         </li>
         <li>
           Finally, be sure to update your node within one week after the release
-          of each new version.
+          of each new version. Follow the{' '}
+          <span className="underline">
+            <Link href="https://discord.com/channels/771503434028941353/816795744680935445">
+              announcements
+            </Link>
+          </span>{' '}
+          channel on our Discord server to hear about new releases.
         </li>
         <li>That’s it - you will gain points every 12 hours.</li>
       </div>

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -128,6 +128,10 @@ const questions: ReadonlyArray<{
         <li>
           Then, run <code>ironfish start</code> and leave that process running.
         </li>
+        <li>
+          Finally, be sure to update your node within one week after the release
+          of each new version.
+        </li>
         <li>That’s it - you will gain points every 12 hours.</li>
       </div>
     ),


### PR DESCRIPTION
## Summary

users need to be running the most recent version of Iron Fish to earn points for hosting a node. there is a one week grace period to update. the website doesn't say anything about this.

adds information on the one week grace period to the phase 3 'About' page, and adds information to the FAQ answer around uptime points.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
