### PR TITLE
fix(sign up form): Incorrect telegram/discord validation

### DIFF
--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -125,10 +125,9 @@ export default function SignUp({
     const noEmail = !$email?.touched
     const noGraffiti = !$graffiti?.touched
     const noGithub = !$github?.touched
-    const noSocial = !$social?.touched
     // for old men
     const noCountry = !$country?.touched
-    const untouched = noEmail || noGraffiti || noSocial || noCountry
+    const untouched = noEmail || noGraffiti || noCountry
     const invalid =
       !$email?.valid || !$graffiti?.valid || !$social?.valid || !$country?.valid
 
@@ -138,7 +137,6 @@ export default function SignUp({
         if (noEmail) $email?.setTouched(true)
         if (noGraffiti) $graffiti?.setTouched(true)
         if (noGithub) $github?.setTouched(true)
-        if (noSocial) $social?.setTouched(true)
         if (noCountry) $country?.setTouched(true)
       } else {
         $setError('Please correct the invalid fields below')


### PR DESCRIPTION
## Summary

Social is not a required field, so we don't need to error if it is untouched. This was causing users to have to click "Sign Up" twice if they did not interact with the discord/telegram input.

## Testing Plan

Manual testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
