### PR TITLE
removes uptime rule from faq

### DIFF
--- a/components/About/data.tsx
+++ b/components/About/data.tsx
@@ -107,11 +107,7 @@ export const callsToAction = {
           graffiti:
         </>
       ),
-      points: [
-        '200 points per transaction',
-        'Weekly limit = 1',
-        'You must have 140 points (1 week) in Hosting a node to have these points count towards tokens.',
-      ],
+      points: ['200 points per transaction', 'Weekly limit = 1'],
       status: Status.New,
       ctaText: 'How to mint an asset',
       href: '/faq#how-to-mint',
@@ -165,11 +161,7 @@ export const callsToAction = {
           your graffiti:
         </>
       ),
-      points: [
-        '200 points per transaction',
-        'Weekly limit = 1',
-        'You must have 140 points (1 week) in Hosting a node to have these points count towards tokens.',
-      ],
+      points: ['200 points per transaction', 'Weekly limit = 1'],
       status: Status.New,
       ctaText: 'How to burn an asset',
       href: '/faq#how-to-burn',
@@ -182,11 +174,7 @@ export const callsToAction = {
           your graffiti:
         </>
       ),
-      points: [
-        '200 points per transaction',
-        'Weekly limit = 1',
-        'You must have 140 points (1 week) in Hosting a node to have these points count towards tokens.',
-      ],
+      points: ['200 points per transaction', 'Weekly limit = 1'],
       status: Status.New,
       ctaText: 'How to send an asset',
       href: '/faq#how-to-send',


### PR DESCRIPTION
## Summary

we're ending the testnet early.

removes mentions of the rule requiring 140 points of uptime for mint, burn, and send points to count.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
