### PR TITLE
Simplify Reward text on Rewards page

### DIFF
--- a/components/Airdrop/RewardItem/RewardItem.tsx
+++ b/components/Airdrop/RewardItem/RewardItem.tsx
@@ -71,7 +71,7 @@ export function RewardItem({ phase, points, iron, chips }: Props) {
             </div>
           </div>
           <div>
-            <span className={clsx('text-lg')}>Open Source Reward in $IRON</span>
+            <span className={clsx('text-lg')}>Reward in $IRON</span>
             <h3
               className={clsx('text-left', 'text-3xl', 'mt-3', 'font-extended')}
             >


### PR DESCRIPTION
## Summary

This shouldn't say Open Source Reward for all pools -- we can just say "Reward".

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
