### PR TITLE
Redirect /redemption to /dashboard/rewards

### DIFF
--- a/pages/redemption.tsx
+++ b/pages/redemption.tsx
@@ -1,0 +1,16 @@
+export const getServerSideProps = () => {
+  return {
+    redirect: {
+      permanent: true,
+      destination: '/dashboard/rewards',
+    },
+  }
+}
+
+/**
+ * This was linked in https://www.ironfish.network/blog/2023/02/28/testnet-rewards,
+ * so we should retain the link and redirect.
+ */
+export default function Redemption() {
+  return null
+}


### PR DESCRIPTION
## Summary

We linked this page in https://www.ironfish.network/blog/2023/02/28/testnet-rewards, so we should at least have a redirect for it in case people bookmarked it.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
