### PR TITLE
Fix max attempts display on rewards page

### DIFF
--- a/components/Airdrop/types/JumioTypes.ts
+++ b/components/Airdrop/types/JumioTypes.ts
@@ -13,15 +13,15 @@ export type JumioWorkflow = {
   can_attempt_reason: string
   can_create: boolean
   can_create_reason: string
-  jumio_account_id: string
-  jumio_web_href: string
-  jumio_workflow_execution_id: string
-  kyc_attempts: number
-  kyc_max_attempts: number
-  kyc_status: KycStatus
-  public_address: string
-  redemption_id: number
-  user_id: number
+  jumio_account_id?: string
+  jumio_web_href?: string
+  jumio_workflow_execution_id?: string
+  kyc_attempts?: number
+  kyc_max_attempts?: number
+  kyc_status?: KycStatus
+  public_address?: string
+  redemption_id?: number
+  user_id?: number
 }
 
 export type KycConfigPool = {

--- a/pages/dashboard/rewards/index.tsx
+++ b/pages/dashboard/rewards/index.tsx
@@ -41,8 +41,8 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
 
   const kycStatus = useGetKycStatus()
   const { response: kycConfig } = useGetKycConfig()
-  const kycAttempts = kycStatus.response?.kyc_attempts
-  const kycMaxAttempts = kycStatus.response?.kyc_max_attempts
+  const kycAttempts = kycStatus.response?.kyc_attempts ?? 0
+  const kycMaxAttempts = kycStatus.response?.kyc_max_attempts ?? 3
   const canAttemptKyc = kycStatus.response?.can_attempt
 
   const needsKyc =
@@ -185,7 +185,7 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
                             >
                               Complete KYC Form
                             </Button>
-                            {typeof kycAttempts === 'number' && (
+                            {kycAttempts > 0 && (
                               <p>
                                 Attempts: {kycAttempts} / {kycMaxAttempts}
                               </p>


### PR DESCRIPTION
## Summary

The Rewards page shows an empty string for the max number of attempts if an attempt hasn't been made yet. This change defaults the value to three, and also defaults the value of kycAttempts to 0. Also updates the type of the KYC endpoint when no attempt has been made yet.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
