### PR TITLE
Fix InfoChip with long line of text inside

### DIFF
--- a/components/Airdrop/InfoChip/InfoChip.tsx
+++ b/components/Airdrop/InfoChip/InfoChip.tsx
@@ -1,18 +1,22 @@
 import clsx from 'clsx'
 
 import { ReactNode, useMemo } from 'react'
-import PendingIcon from './icons/Pending'
-import WarningIcon from './icons/Warning'
 
 import styles from './InfoChip.module.css'
 
 type ChipProps = {
   children: ReactNode
   variant: 'info' | 'pending' | 'warning' | 'complete'
-  icon?: boolean
+  align?: 'left' | 'center'
+  wrap?: boolean
 }
 
-export function InfoChip({ children, variant, icon }: ChipProps) {
+export function InfoChip({
+  children,
+  variant,
+  align,
+  wrap = false,
+}: ChipProps) {
   const colors = useMemo(() => {
     return {
       info: styles.info,
@@ -37,14 +41,14 @@ export function InfoChip({ children, variant, icon }: ChipProps) {
         colors
       )}
     >
-      {icon && (
-        <div className={clsx('hidden', 'md:block')}>
-          {variant === 'warning' && <WarningIcon />}
-          {variant === 'pending' && <PendingIcon />}
-          {variant === 'complete' && <WarningIcon />}
-        </div>
-      )}
-      <div className="md:text-center md:whitespace-nowrap">{children}</div>
+      <div
+        className={clsx(
+          align ? `text-${align}` : 'md:text-center',
+          wrap && 'md:whitespace-nowrap'
+        )}
+      >
+        {children}
+      </div>
     </div>
   )
 }

--- a/components/Airdrop/InfoChip/InfoChip.tsx
+++ b/components/Airdrop/InfoChip/InfoChip.tsx
@@ -44,7 +44,7 @@ export function InfoChip({
       <div
         className={clsx(
           align ? `text-${align}` : 'md:text-center',
-          wrap && 'md:whitespace-nowrap'
+          !wrap && 'md:whitespace-nowrap'
         )}
       >
         {children}

--- a/components/Airdrop/hooks/useApprovalStatusChip.tsx
+++ b/components/Airdrop/hooks/useApprovalStatusChip.tsx
@@ -21,7 +21,7 @@ export function useApprovalStatusChip({
   return useMemo(() => {
     if (status === 'AIRDROP_INELIGIBLE') {
       return (
-        <InfoChip variant="warning">
+        <InfoChip align="left" variant="warning" wrap>
           Airdrop Unavailable{!!ineligibleReason && `: ${ineligibleReason}`}
         </InfoChip>
       )


### PR DESCRIPTION
## Summary

<img width="1249" alt="Screenshot 2023-03-08 at 4 01 23 PM" src="https://user-images.githubusercontent.com/3639170/223871824-d0790998-1461-428f-89e8-d6186a3f5646.png">
<img width="1249" alt="Screenshot 2023-03-08 at 4 01 35 PM" src="https://user-images.githubusercontent.com/3639170/223871849-9f2e7e71-a4a5-45c9-b7ea-cbcc306fb826.png">


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
