### PR TITLE
Add edit wallet address modal

### DIFF
--- a/components/Airdrop/KYCSteps/StepSubmitAddress.tsx
+++ b/components/Airdrop/KYCSteps/StepSubmitAddress.tsx
@@ -53,10 +53,7 @@ export default function StepSubmitAddress({ onNext, storedAddress }: Props) {
             <p className="mb-2">
               <code>ironfish wallet:address</code>
             </p>
-            <p>
-              Once you begin the KYC process, you will not be able to edit your
-              address, so please ensure you are submitting the correct address.
-            </p>
+            <p>Please ensure you are submitting the correct address.</p>
             <div className={clsx('flex', 'flex-col')}>
               {pubAddress && (
                 <TextField className="max-w-full" {...pubAddress} />

--- a/components/Airdrop/WalletAddress/WalletAddress.tsx
+++ b/components/Airdrop/WalletAddress/WalletAddress.tsx
@@ -1,11 +1,219 @@
+import TextField from 'components/Form/TextField'
+import { UNSET } from 'utils/forms'
+import { useField, WHITESPACE } from 'hooks/useForm'
 import clsx from 'clsx'
+import { useCallback, useState } from 'react'
+import { magic } from 'utils'
 
 export default function WalletAddress({ address }: { address: string }) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const handleSubmit = useCallback(async (newAddress: string) => {
+    setIsSubmitting(true)
+
+    try {
+      const apiKey = (await magic?.user.getIdToken()) ?? ''
+
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/kyc`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          public_address: newAddress,
+        }),
+      })
+      if (!res.ok) {
+        throw new Error('Error fetching KYC workflow')
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(err)
+    } finally {
+      setIsEditing(false)
+      setIsSubmitting(false)
+    }
+  }, [])
+
+  return (
+    <>
+      <div>
+        <p className={clsx('mb-2', 'text-lg')}>Submitted wallet address:</p>
+        <div
+          className={clsx(
+            'flex',
+            'items-start',
+            'flex-col-reverse',
+            'md:flex-row',
+            'gap-2'
+          )}
+        >
+          <button
+            onClick={() => setIsEditing(true)}
+            className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold ring-1 ring-inset ring-gray-300 sm:mt-0 sm:w-auto hover:bg-gray-50"
+          >
+            Edit
+          </button>
+          <div
+            className={clsx(
+              'py-2',
+              'px-4',
+              'bg-gray-100',
+              'rounded-md',
+              'break-all'
+            )}
+          >
+            <code>{address}</code>
+          </div>
+        </div>
+      </div>
+      {isEditing && (
+        <EditAddressModal
+          loading={isSubmitting}
+          onCancel={() => setIsEditing(false)}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </>
+  )
+}
+
+const publicAddressField = {
+  id: 'address',
+  label: 'Public Address',
+  placeholder: 'Your Iron Fish public address',
+  defaultValue: UNSET,
+  validation: (address: string) => address.length == 64,
+  defaultErrorText: `A 64-character string is required for public address`,
+  whitespace: WHITESPACE.BANNED,
+}
+
+const confirmAddressField = {
+  id: 'confirmAddress',
+  label: 'Confirm Public Address',
+  placeholder: '',
+  defaultValue: UNSET,
+  validation: () => true,
+  defaultErrorText: `This field must match the public address above`,
+  whitespace: WHITESPACE.BANNED,
+}
+
+function EditAddressModal({
+  onCancel,
+  onSubmit,
+  loading,
+}: {
+  onCancel: () => void
+  onSubmit: (address: string) => void
+  loading: boolean
+}) {
+  const pubAddress = useField(publicAddressField)
+  const confirmPubAddress = useField(confirmAddressField)
+
   return (
     <div
-      className={clsx('p-4', 'bg-gray-100', 'mt-4', 'rounded-md', 'break-all')}
+      className="relative z-10"
+      aria-labelledby="modal-title"
+      role="dialog"
+      aria-modal="true"
     >
-      <code>{address}</code>
+      <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+
+      <div className="fixed inset-0 z-10 overflow-y-auto">
+        <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+          <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+            {loading && (
+              <div className="inset-0 bg-gray-100 bg-opacity-50 absolute z-10 flex items-center justify-center">
+                <div
+                  className="inline-block h-12 w-12 animate-spin rounded-full border-4 border-solid border-current border-r-transparent align-[-0.125em] motion-reduce:animate-[spin_1.5s_linear_infinite]"
+                  role="status"
+                >
+                  <span className="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]">
+                    Loading...
+                  </span>
+                </div>
+              </div>
+            )}
+            <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+              <div className="sm:flex sm:items-start">
+                <div className="mt-3 text-left sm:mt-0 sm:ml-4">
+                  <h3
+                    className={clsx(
+                      'text-xl',
+                      'md:text-2xl',
+                      'mt-auto',
+                      'mb-4'
+                    )}
+                    id="modal-title"
+                  >
+                    Edit Wallet Address
+                  </h3>
+                  <div>
+                    <p className="mb-2">
+                      Please provide the public wallet address of the account
+                      where you&apos;d like your $IRON airdropped. You can
+                      retrieve this using the command:
+                    </p>
+                    <p className="mb-2">
+                      <code>ironfish wallet:address</code>
+                    </p>
+                    <div className={clsx('flex', 'flex-col')}>
+                      {pubAddress && (
+                        <TextField className="max-w-full" {...pubAddress} />
+                      )}
+                      {confirmPubAddress && (
+                        <TextField
+                          {...confirmPubAddress}
+                          className="max-w-full"
+                        />
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+              <button
+                type="button"
+                className={clsx(
+                  'inline-flex',
+                  'w-full',
+                  'justify-center',
+                  'rounded-md',
+                  'bg-ifpink',
+                  'px-3',
+                  'py-2',
+                  'text-sm',
+                  'font-semibold',
+                  'shadow-sm',
+                  'sm:ml-3',
+                  'sm:w-auto',
+                  'hover:bg-ifpinkdark'
+                )}
+                onClick={() => {
+                  if (!pubAddress?.value || !pubAddress?.valid) {
+                    pubAddress?.setValid(false)
+                  } else if (pubAddress?.value !== confirmPubAddress?.value) {
+                    confirmPubAddress?.setValid(false)
+                  } else {
+                    onSubmit(pubAddress.value)
+                  }
+                }}
+              >
+                Submit
+              </button>
+              <button
+                onClick={onCancel}
+                type="button"
+                className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold ring-1 ring-inset ring-gray-300 sm:mt-0 sm:w-auto hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/components/Airdrop/WalletAddress/WalletAddress.tsx
+++ b/components/Airdrop/WalletAddress/WalletAddress.tsx
@@ -82,7 +82,8 @@ export default function WalletAddress({ address }: { address: string }) {
             'items-start',
             'flex-col-reverse',
             'md:flex-row',
-            'gap-2'
+            'gap-2',
+            'md:items-center'
           )}
         >
           <button

--- a/components/Toast/Toast.tsx
+++ b/components/Toast/Toast.tsx
@@ -19,6 +19,7 @@ export const Toast = ({
         'fixed',
         'z-30',
         'flex',
+        'left-0',
         styles.toast,
         topAligned
           ? showNotification

--- a/pages/dashboard/rewards/index.tsx
+++ b/pages/dashboard/rewards/index.tsx
@@ -47,10 +47,6 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
     canAttemptKyc &&
     ['NOT_STARTED', 'TRY_AGAIN', 'IN_PROGRESS'].includes(kycStatus.status)
 
-  const showAddress = ['WAITING_FOR_CALLBACK', 'SUBMITTED'].includes(
-    kycStatus.status
-  )
-
   const approvalStatusChip = useApprovalStatusChip({
     status: canAttemptKyc ? kycStatus.status : 'AIRDROP_INELIGIBLE',
     kycConfig: kycConfig,
@@ -60,6 +56,10 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
       ? kycStatus.response?.can_attempt_reason
       : undefined,
   })
+
+  const userAddress =
+    kycStatus.response?.public_address ??
+    'b04bdad05643e406b160892b4d3a20fac6adbb8b35e0b7ce1bccf2be8ff6eecc'
 
   if (isLoading || !kycConfig || !userAllTimeMetrics || kycStatus.loading) {
     return <Loader />
@@ -131,6 +131,11 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
                       <p className={clsx('text-xl', 'md:text-2xl', 'mt-auto')}>
                         {metadata?.graffiti || '—'}
                       </p>
+                      {userAddress && (
+                        <div className={clsx('mt-4', 'mr-4')}>
+                          <WalletAddress address={userAddress} />
+                        </div>
+                      )}
                     </div>
                     <FishAvatar color="pink" />
                   </div>
@@ -152,14 +157,6 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
                           {approvalStatusChip}
                         </div>
                       </div>
-                      {showAddress && kycStatus.response?.public_address && (
-                        <div>
-                          <p>Submitted wallet address:</p>
-                          <WalletAddress
-                            address={kycStatus.response.public_address}
-                          />
-                        </div>
-                      )}
                       {needsKyc && (
                         <>
                           <ul className={clsx('list-disc', 'px-4')}>

--- a/pages/dashboard/rewards/index.tsx
+++ b/pages/dashboard/rewards/index.tsx
@@ -57,9 +57,7 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
       : undefined,
   })
 
-  const userAddress =
-    kycStatus.response?.public_address ??
-    'b04bdad05643e406b160892b4d3a20fac6adbb8b35e0b7ce1bccf2be8ff6eecc'
+  const userAddress = kycStatus.response?.public_address
 
   if (isLoading || !kycConfig || !userAllTimeMetrics || kycStatus.loading) {
     return <Loader />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -109,6 +109,9 @@ module.exports = {
         iflightbeige: {
           DEFAULT: '#FFEFD7',
         },
+        ifpinkdark: {
+          DEFAULT: '#DE83F0',
+        },
       },
       fontFamily: {
         favorit: ['favorit-regular', 'sans-serif'],


### PR DESCRIPTION
## Summary

Adds a way to edit the previously submitted wallet address on the "/dashboard/rewards" page.

## Testing Plan

Manual testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
