### PR TITLE
fix: show 0 reward for no points in category

### DIFF
--- a/pages/dashboard/rewards/index.tsx
+++ b/pages/dashboard/rewards/index.tsx
@@ -209,7 +209,9 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
                           key={i}
                           poolName={pool.name}
                           points={userAllTimeMetrics.pool_points[pool.name]}
-                          iron={null}
+                          iron={
+                            userAllTimeMetrics.pool_points[pool.name] ? null : 0
+                          }
                           chips={
                             <>
                               <InfoChip variant="warning">


### PR DESCRIPTION
## Summary
If user has no points, we don't need to show `TBD`, we can show 0
## Testing Plan
test in staging
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
