### PR TITLE
Simplified down KYC copy

### DIFF
--- a/components/Airdrop/KYCSteps/StepConfirmJumioStart.tsx
+++ b/components/Airdrop/KYCSteps/StepConfirmJumioStart.tsx
@@ -12,15 +12,22 @@ export default function StepConfirmJumioStart({ onNext }: Props) {
       <div className={clsx('p-12', 'flex', 'flex-col')}>
         <h1 className={clsx('font-extended', 'text-4xl', 'mb-8')}>KYC Form</h1>
         <p className="mb-2">
-          You are about to begin the identity verification process. In order to
-          successfully complete this process, you will be asked to provide a
-          valid government-issued ID. Please ensure you have a valid ID ready.
+          KYC will require you to upload a passport, driver&#39;s license or
+          government identity card.
         </p>
-        <p className="mb-2">
-          Once started, you will have 15 minutes to finish. If you do not finish
-          in time, the KYC process will fail.
+        <p className="mb-2">You will have 15 minutes to complete KYC.</p>
+        <p>
+          Click here to{' '}
+          <a
+            className="underline"
+            target="_blank"
+            href="https://coda.io/d/_dte_X_jrtqj/KYC-FAQ_su_vf#_luc1r"
+            rel="noreferrer"
+          >
+            see our KYC FAQ
+          </a>
+          .
         </p>
-        <p>You will have up to 3 attempts to complete the KYC process.</p>
         <div className="mb-auto" />
         <div className={clsx('flex', 'justify-end')}>
           <Button


### PR DESCRIPTION
## Summary
I spoke with skylar about the copy here and we simplified it down and also now link to our new KYC guide.

*Before*
<img width="679" alt="Screen Shot 2023-03-18 at 4 25 25 PM" src="https://user-images.githubusercontent.com/458976/226136811-d70535ef-b63e-4126-a3f4-15607419dd20.png">

*After*
<img width="675" alt="Screen Shot 2023-03-18 at 4 24 43 PM" src="https://user-images.githubusercontent.com/458976/226136817-869fd66a-d6f2-4566-936e-b3609b395ca8.png">

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
