### PR TITLE
Render failure reason from API

### DIFF
--- a/components/Airdrop/KYCSteps/StepKYCComplete/StepKYCComplete.tsx
+++ b/components/Airdrop/KYCSteps/StepKYCComplete/StepKYCComplete.tsx
@@ -12,11 +12,14 @@ export default function StepKYCComplete() {
 
   const { response, status, loading } = useGetKycStatus(4000)
   const { response: kycConfig } = useGetKycConfig()
+
   const approvalStatusChip = useApprovalStatusChip({
     status: response?.can_attempt ? status : 'AIRDROP_INELIGIBLE',
     kycConfig: kycConfig,
     details: response?.can_attempt_reason ?? undefined,
+    helpUrl: response?.help_url ?? undefined,
   })
+
   const isStatusPending =
     loading || ['WAITING_FOR_CALLBACK', 'IN_PROGRESS'].includes(status)
 

--- a/components/Airdrop/hooks/useApprovalStatusChip.tsx
+++ b/components/Airdrop/hooks/useApprovalStatusChip.tsx
@@ -5,28 +5,49 @@ import { getNextEligiblePhase } from './usePhaseStatus'
 import type { KycConfig, KycStatus } from '../types/JumioTypes'
 import { titlesByPhase } from '../RewardItem/RewardItem'
 
-function withDetails(message: string, details?: string) {
+function withDetails(
+  message: string,
+  details?: string,
+  helpUrl?: string
+): JSX.Element {
   if (!details) {
-    return message
+    return <>{message}</>
   }
 
-  return `${message}: ${details}`
+  return (
+    <span>
+      {message}: {details}
+      {helpUrl ? (
+        <>
+          {' '}
+          <a href={helpUrl} target="_blank" rel="noreferrer">
+            Learn more here
+          </a>
+          .
+        </>
+      ) : (
+        ''
+      )}
+    </span>
+  )
 }
 
 export function useApprovalStatusChip({
   status,
   kycConfig,
   details,
+  helpUrl,
 }: {
   status: KycStatus | 'NOT_STARTED' | 'AIRDROP_INELIGIBLE'
   kycConfig: KycConfig | null
   details?: string
+  helpUrl?: string
 }) {
   return useMemo(() => {
     if (status === 'AIRDROP_INELIGIBLE') {
       return (
         <InfoChip align="left" variant="warning" wrap>
-          {withDetails('Airdrop Unavailable', details)}
+          {withDetails('Airdrop Unavailable', details, helpUrl)}
         </InfoChip>
       )
     }
@@ -60,7 +81,15 @@ export function useApprovalStatusChip({
     if (status === 'FAILED') {
       return (
         <InfoChip variant="warning">
-          {withDetails('KYC Declined', details)}
+          {withDetails('KYC Denied', details, helpUrl)}
+        </InfoChip>
+      )
+    }
+
+    if (status === 'TRY_AGAIN') {
+      return (
+        <InfoChip variant="warning">
+          {withDetails('KYC Failed', details, helpUrl)}
         </InfoChip>
       )
     }
@@ -70,22 +99,11 @@ export function useApprovalStatusChip({
       'MMM d'
     )
 
-    if (status === 'TRY_AGAIN') {
-      return (
-        <InfoChip variant="warning">
-          {withDetails(
-            `KYC Failed, try again before ${nextPhaseDeadline}`,
-            details
-          )}
-        </InfoChip>
-      )
-    }
-
     return (
       <InfoChip variant={'warning'}>
         KYC Deadline for {titlesByPhase[nextEligiblePhase.name]}:{' '}
         {nextPhaseDeadline}
       </InfoChip>
     )
-  }, [status, kycConfig, details])
+  }, [status, kycConfig, details, helpUrl])
 }

--- a/components/Airdrop/types/JumioTypes.ts
+++ b/components/Airdrop/types/JumioTypes.ts
@@ -22,6 +22,7 @@ export type JumioWorkflow = {
   public_address?: string
   redemption_id?: number
   user_id?: number
+  help_url?: string
 }
 
 export type KycConfigPool = {

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -39,6 +39,7 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
     status: statusResponse?.can_attempt ? status : 'AIRDROP_INELIGIBLE',
     kycConfig,
     details: statusResponse?.can_attempt_reason ?? undefined,
+    helpUrl: statusResponse?.help_url ?? undefined,
   })
 
   const needsKyc =

--- a/pages/dashboard/rewards/index.tsx
+++ b/pages/dashboard/rewards/index.tsx
@@ -51,6 +51,7 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
     status: canAttemptKyc ? kycStatus.status : 'AIRDROP_INELIGIBLE',
     kycConfig: kycConfig,
     details: kycStatus.response?.can_attempt_reason ?? undefined,
+    helpUrl: kycStatus.response?.help_url ?? undefined,
   })
 
   const userAddress = kycStatus.response?.public_address


### PR DESCRIPTION
## Summary

This now renders the failure reason including the help URL according to figma.

<img width="638" alt="Screen Shot 2023-03-20 at 11 18 17 PM" src="https://user-images.githubusercontent.com/458976/226510125-5c6bb9a3-01dd-4aef-a1f7-453e572be9f1.png">

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
