### PR TITLE
Link to Phase3 archive for blocks and transactions

### DIFF
--- a/components/user/EventRow.tsx
+++ b/components/user/EventRow.tsx
@@ -119,10 +119,10 @@ const makeLinkForEvent = (type: EventType, metadata?: ApiEventMetadata) => {
     'block_hash' in metadata &&
     EVENTS_WITH_TRANSACTIONS.includes(type)
   ) {
-    return `https://explorer.ironfish.network/transaction/${metadata.transaction_hash}`
+    return `https://phase3.explorer.ironfish.network/transaction/${metadata.transaction_hash}`
   }
   if ('hash' in metadata && type === EventType.BLOCK_MINED) {
-    return `https://explorer.ironfish.network/blocks/${metadata.hash}`
+    return `https://phase3.explorer.ironfish.network/blocks/${metadata.hash}`
   }
   return (metadata as ApiEventMetadataWithLink).url
 }


### PR DESCRIPTION
## Summary
Going forward the mainnet API will be used for mainnet blocks. However we still need to use it for KYC and users to view their profile for a while into mainnet. The user profile contains links to blocks and transactions the user was a part of but these will now be on phase3.explorer.ironfish.testnet NOT explorer.ironfish.testnet. So the links need to change here

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
