### PR TITLE
Add error and statusCode in /me response

### DIFF
--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -235,13 +235,21 @@ export async function getUserDetails(
   token: string
 ): Promise<ApiUserMetadata | ApiError | LocalError> {
   try {
-    const data = await fetch(`${API_URL}/me`, {
+    const response = await fetch(`${API_URL}/me`, {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
     })
-    return data.json()
+
+    const data = await response.json()
+
+    if (response.status !== 200) {
+      data.statusCode = response.status
+      data.error = data.code
+    }
+
+    return data
   } catch (e) {
     return new LocalError((e as Error).message, ENDPOINT_UNAVAILABLE)
   }


### PR DESCRIPTION
## Summary
In case of login error, the front end is not read the /me response correctly.

There is one place checking statusCode https://github.com/iron-fish/website-testnet/blob/master/pages/callback.tsx#L34
Another place checking error  https://github.com/iron-fish/website-testnet/blob/master/hooks/useLogin.ts#L65

Add statusCode and error in the /me response

## Testing Plan
vercel
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@dgca @iron-fish/engineering 