### PR TITLE
Check jwt token in loginContext

### DIFF
--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -235,21 +235,17 @@ export async function getUserDetails(
   token?: string
 ): Promise<ApiUserMetadata | ApiError | LocalError> {
   try {
-    let response
-    if (!token) {
-      response = await fetch(`${API_URL}/me`, {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
-    } else {
-      response = await fetch(`${API_URL}/me`, {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-      })
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
     }
+
+    if (token) {
+      headers.Authorization = `Bearer ${token}`
+    }
+
+    const response = await fetch(`${API_URL}/me`, {
+      headers,
+    })
 
     const data = await response.json()
 

--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -232,15 +232,24 @@ export async function login(email: string): Promise<any> {
 }
 
 export async function getUserDetails(
-  token: string
+  token?: string
 ): Promise<ApiUserMetadata | ApiError | LocalError> {
   try {
-    const response = await fetch(`${API_URL}/me`, {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-    })
+    let response
+    if (!token) {
+      response = await fetch(`${API_URL}/me`, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    } else {
+      response = await fetch(`${API_URL}/me`, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      })
+    }
 
     const data = await response.json()
 

--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -131,18 +131,13 @@ export function useLogin(config: LoginProps = {}) {
   return loginContext
 }
 
-function getCookie(cname: string) {
-  const name = cname + '='
-  const ca = document.cookie.split(';')
-  for (let i = 0; i < ca.length; i++) {
-    const c = ca[i].trim()
-
-    if (c.indexOf(name) == 0) {
-      return c.substring(name.length, c.length)
-    }
-  }
-
-  return ''
+function getCookie(name: string) {
+  return (
+    document.cookie
+      .split(/;\s?/)
+      .find(item => item.startsWith(`${name}=`))
+      ?.slice(name.length + 1) ?? ''
+  )
 }
 
 export type LoginContext = ReturnType<typeof useLogin>

--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -43,6 +43,11 @@ export function useLogin(config: LoginProps = {}) {
       token = await magic.user.getIdToken()
     } catch (error) {}
 
+    const jwtToken = getCookie('ironfish_jwt')
+    if (jwtToken !== '') {
+      
+    }
+
     if (!token) {
       if (redirect) {
         // if redirect string is provided and we're not logged in, cya!
@@ -114,6 +119,20 @@ export function useLogin(config: LoginProps = {}) {
     setRawMetadata: $setMetadata,
   }
   return loginContext
+}
+
+function getCookie(cname: string) {
+  const name = cname + '='
+  const ca = document.cookie.split(';')
+  for (let i = 0; i < ca.length; i++) {
+    const c = ca[i].trim()
+
+    if (c.indexOf(name) == 0) {
+      return c.substring(name.length, c.length)
+    }
+  }
+
+  return ''
 }
 
 export type LoginContext = ReturnType<typeof useLogin>

--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -46,7 +46,12 @@ export function useLogin(config: LoginProps = {}) {
     const jwtToken = getCookie('ironfish_jwt')
     if (jwtToken !== '') {
       const details = await getUserDetails()
-      if (details.statusCode && details.statusCode === 200) {
+      if (
+        !(details instanceof LocalError) &&
+        !('error' in details) &&
+        details.statusCode &&
+        details.statusCode === 200
+      ) {
         $setStatus(STATUS.LOADED)
         $setMetadata(details)
         return true

--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -45,7 +45,12 @@ export function useLogin(config: LoginProps = {}) {
 
     const jwtToken = getCookie('ironfish_jwt')
     if (jwtToken !== '') {
-      
+      const details = await getUserDetails()
+      if (details.statusCode && details.statusCode === 200) {
+        $setStatus(STATUS.LOADED)
+        $setMetadata(details)
+        return true
+      }
     }
 
     if (!token) {


### PR DESCRIPTION
## Summary

The new login flow set jwt token in the cookie, example of cookie string
_ga=GA1.1.1480516078.1663010890; _ga_GJD73W9V3M=GS1.1.1680053950.84.0.1680053950.0.0.0; ironfish_jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ5YWp1bi5nYW8xMDA0QGdtYWlsLmNvbSIsImlhdCI6MTY4MDY0OTM5OTU2NywiZXhwIjoxNjgwNjQ5NDg1OTY3fQ.QCRG_2Q30bSYQXAmpAEuPx8XqaNFQ8YbVxBtDWKcyMA

When access the /dashboard with valid jwt token, we should let the user through. This PR adds the logic to check jwt token in LoginContext. It will call backend /me endpoint to validate the token. If /me response has 200 status code, the user pass the auth.

## Testing Plan
Vercel

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@dgca @rohanjadvani 