### PR TITLE
Call user api when token is empty

### DIFF
--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -43,8 +43,7 @@ export function useLogin(config: LoginProps = {}) {
       token = await magic.user.getIdToken()
     } catch (error) {}
 
-    const jwtToken = getCookie('ironfish_jwt')
-    if (jwtToken !== '') {
+    if (!token) {
       const details = await getUserDetails()
       if (
         !(details instanceof LocalError) &&
@@ -56,9 +55,7 @@ export function useLogin(config: LoginProps = {}) {
         $setMetadata(details)
         return true
       }
-    }
 
-    if (!token) {
       if (redirect) {
         // if redirect string is provided and we're not logged in, cya!
         // if this is kept as a static Router.push, it _does not_ work


### PR DESCRIPTION
## Summary
Remove the logic to check jwt token value because jwt token is not available in document.cookie.

If magic link token is empty, call getUser endpoint. If the request has the right cookie, this call will succeed.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@dgca 