### PR TITLE
Include cookie in the request headers

### DIFF
--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -245,6 +245,7 @@ export async function getUserDetails(
 
     const response = await fetch(`${API_URL}/me`, {
       headers,
+      credentials: 'include',
     })
 
     const data = await response.json()


### PR DESCRIPTION
## Summary
The fetch /me request does not have cookie because the domains don’t match. The front end is in testnet.ironfish.network and fetch request is in api.ironfish.network. 

Include the cookie in the request header manually
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@dgca 