### PR TITLE
Include cookies with jwt token for all KYC related backend calls

### DIFF
--- a/apiClient/client.ts
+++ b/apiClient/client.ts
@@ -238,6 +238,7 @@ export async function logout(): Promise<boolean> {
       headers: {
         'Content-Type': 'application/json',
       },
+      credentials: 'include',
     })
 
     if (response.status !== 200) {

--- a/components/Airdrop/KYCSteps/KYCSteps.tsx
+++ b/components/Airdrop/KYCSteps/KYCSteps.tsx
@@ -8,14 +8,20 @@ import { JumioWorkflow } from '../types/JumioTypes'
 
 async function setKycStatusProcessing() {
   try {
-    const apiKey = (await magic?.user.getIdToken()) ?? ''
+    const token = await magic?.user.getIdToken()
+
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+    }
+
+    if (token) {
+      headers.Authorization = `Bearer ${token}`
+    }
 
     await fetch(`${process.env.NEXT_PUBLIC_API_URL}/kyc/complete`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
+      headers,
+      credentials: 'include',
     })
   } catch (err) {
     // eslint-disable-next-line no-console

--- a/components/Airdrop/hooks/useCreateKycFlow.ts
+++ b/components/Airdrop/hooks/useCreateKycFlow.ts
@@ -19,14 +19,20 @@ function useCreateKycFlow(userAddress: string, shouldCreateKycFlow: boolean) {
       setPostStatus('LOADING')
 
       try {
-        const apiKey = (await magic?.user.getIdToken()) ?? ''
+        const token = await magic?.user.getIdToken()
+
+        const headers: HeadersInit = {
+          'Content-Type': 'application/json',
+        }
+    
+        if (token) {
+          headers.Authorization = `Bearer ${token}`
+        }
 
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/kyc`, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${apiKey}`,
-          },
+          headers,
+          credentials: 'include',
           body: JSON.stringify({
             public_address: userAddress,
           }),

--- a/components/Airdrop/hooks/useCreateKycFlow.ts
+++ b/components/Airdrop/hooks/useCreateKycFlow.ts
@@ -24,7 +24,7 @@ function useCreateKycFlow(userAddress: string, shouldCreateKycFlow: boolean) {
         const headers: HeadersInit = {
           'Content-Type': 'application/json',
         }
-    
+
         if (token) {
           headers.Authorization = `Bearer ${token}`
         }

--- a/components/Airdrop/hooks/useGetKycStatus.ts
+++ b/components/Airdrop/hooks/useGetKycStatus.ts
@@ -10,13 +10,18 @@ export function useGetKycStatus(interval?: number) {
   useEffect(() => {
     async function doFetch() {
       try {
-        const apiKey = (await magic?.user.getIdToken()) ?? ''
+        const token = await magic?.user.getIdToken()
+
+        const headers: HeadersInit = {}
+
+        if (token) {
+          headers.Authorization = `Bearer ${token}`
+        }
 
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/kyc`, {
           method: 'GET',
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
+          headers,
+          credentials: 'include',
         })
 
         const data = await res.json()


### PR DESCRIPTION
## Summary
The jwt token cookies need to be manually included in the request to backend server. 
Add `credentials: 'include'` to all the calls to backend requests.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@dgca @rohanjadvani 