### PR TITLE
Catch error when get magic link token

### DIFF
--- a/components/Airdrop/WalletAddress/WalletAddress.tsx
+++ b/components/Airdrop/WalletAddress/WalletAddress.tsx
@@ -43,14 +43,23 @@ export default function WalletAddress({ address }: { address: string }) {
       setIsSubmitting(true)
 
       try {
-        const apiKey = (await magic?.user.getIdToken()) ?? ''
+        let token
+        try {
+          token = await magic?.user.getIdToken()
+        } catch (error) {}
+
+        const headers: HeadersInit = {
+          'Content-Type': 'application/json',
+        }
+
+        if (token) {
+          headers.Authorization = `Bearer ${token}`
+        }
 
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/kyc`, {
           method: 'PUT',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${apiKey}`,
-          },
+          headers,
+          credentials: 'include',
           body: JSON.stringify({
             public_address: newAddress,
           }),

--- a/components/Airdrop/hooks/useCreateKycFlow.ts
+++ b/components/Airdrop/hooks/useCreateKycFlow.ts
@@ -19,7 +19,10 @@ function useCreateKycFlow(userAddress: string, shouldCreateKycFlow: boolean) {
       setPostStatus('LOADING')
 
       try {
-        const token = await magic?.user.getIdToken()
+        let token
+        try {
+          token = await magic?.user.getIdToken()
+        } catch (error) {}
 
         const headers: HeadersInit = {
           'Content-Type': 'application/json',

--- a/components/Airdrop/hooks/useGetKycStatus.ts
+++ b/components/Airdrop/hooks/useGetKycStatus.ts
@@ -10,8 +10,10 @@ export function useGetKycStatus(interval?: number) {
   useEffect(() => {
     async function doFetch() {
       try {
-        const token = await magic?.user.getIdToken()
-
+        let token
+        try {
+          token = await magic?.user.getIdToken()
+        } catch (error) {}
         const headers: HeadersInit = {}
 
         if (token) {

--- a/pages/logout.tsx
+++ b/pages/logout.tsx
@@ -13,7 +13,10 @@ type LogoutProps = {
 export default function Logout({ loginContext }: LogoutProps) {
   useEffect(() => {
     const sayGoodbye = async () => {
-      let loggedOut = await magic?.user.logout()
+      let loggedOut
+      try {
+        loggedOut = await magic?.user.logout()
+      } catch (error) {}
 
       if (!loggedOut) {
         loggedOut = await logout()


### PR DESCRIPTION
## Summary
When use jwt token, magic link get token function will throw error
```
fetch error Error: Magic RPC Error: [-32603] Internal error: User denied account access.
```
Silence these error so that jwt token can be used.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@dgca 