### PR TITLE
Add total rewards and airdrop hash to rewards page

### DIFF
--- a/components/Airdrop/InfoChip/InfoChip.module.css
+++ b/components/Airdrop/InfoChip/InfoChip.module.css
@@ -18,3 +18,7 @@
   background-color: #EBFBF4;
 }
 
+.airdrop {
+  color: #5FC89A;
+  background-color: #192D23;
+}

--- a/components/Airdrop/InfoChip/InfoChip.tsx
+++ b/components/Airdrop/InfoChip/InfoChip.tsx
@@ -6,9 +6,10 @@ import styles from './InfoChip.module.css'
 
 type ChipProps = {
   children: ReactNode
-  variant: 'info' | 'pending' | 'warning' | 'complete'
+  variant: 'info' | 'pending' | 'warning' | 'complete' | 'airdrop'
   align?: 'left' | 'center'
   wrap?: boolean
+  className?: string
 }
 
 export function InfoChip({
@@ -16,6 +17,7 @@ export function InfoChip({
   variant,
   align,
   wrap = false,
+  className,
 }: ChipProps) {
   const colors = useMemo(() => {
     return {
@@ -23,6 +25,7 @@ export function InfoChip({
       pending: styles.pending,
       warning: styles.warning,
       complete: styles.complete,
+      airdrop: styles.airdrop,
     }[variant]
   }, [variant])
   return (
@@ -38,7 +41,8 @@ export function InfoChip({
         'items-center',
         'gap-2',
         'justify-center',
-        colors
+        colors,
+        className
       )}
     >
       <div

--- a/components/Airdrop/TotalRewards/TotalRewards.tsx
+++ b/components/Airdrop/TotalRewards/TotalRewards.tsx
@@ -1,0 +1,168 @@
+import clsx from 'clsx'
+import { Box } from 'components/OffsetBorder/Box'
+import { InfoChip } from '../InfoChip/InfoChip'
+import useClipboard from 'react-use-clipboard'
+import styles from './totalRewards.module.css'
+import ActivityCopy from 'components/icons/ActivityCopy'
+
+type Props = {
+  totalPoints: number | null
+  totalIron: number | null
+  airdropHash: string | null
+}
+
+export const titlesByPhase = {
+  pool_three: 'Pull Request Points',
+  pool_one: 'Phase 1 Points',
+  pool_two: 'Phase 2 Points',
+  pool_four: 'Phase 3 Points',
+}
+
+const longestPoolName = Object.values(titlesByPhase).sort(
+  (a, b) => b.length - a.length
+)[0]
+
+export function TotalRewards({ totalPoints, totalIron, airdropHash }: Props) {
+  if (!totalPoints || !totalIron || !airdropHash) {
+    return null
+  }
+
+  return (
+    <div className="mb-3 w-full">
+      <Box behind={'transaprent'} background="bg-black text-white">
+        <div
+          className={clsx(
+            'md:p-8',
+            'md:flex-row',
+            'md:gap-0',
+            'gap-10',
+            'flex-col',
+            'flex',
+            'p-4'
+          )}
+        >
+          <div className="mr-8">
+            <div className={clsx('relative')}>
+              <div
+                aria-hidden
+                className={clsx(
+                  'text-lg',
+                  'text-transparent',
+                  'whitespace-nowrap',
+                  'select-none'
+                )}
+              >
+                {longestPoolName}
+              </div>
+              <div
+                className={clsx(
+                  'text-lg',
+                  'absolute',
+                  'inset-0',
+                  'whitespace-nowrap'
+                )}
+              >
+                Total Points
+              </div>
+            </div>
+            <div className={clsx('flex', 'items-center', 'justify-between')}>
+              <h3
+                className={clsx(
+                  'text-left',
+                  'text-3xl',
+                  'mt-3',
+                  'font-extended'
+                )}
+              >
+                {totalPoints !== null
+                  ? totalPoints.toLocaleString('en-US')
+                  : 'n/a'}
+              </h3>
+              <span className={clsx('hidden', 'md:block', 'mt-2')}>=</span>
+            </div>
+          </div>
+          <div>
+            <span className={clsx('text-lg')}>Total Rewards</span>
+            <h3
+              className={clsx('text-left', 'text-3xl', 'mt-3', 'font-extended')}
+            >
+              {totalIron !== null ? totalIron.toLocaleString('en-US') : 'n/a'}
+            </h3>
+          </div>
+          <div
+            className={clsx(
+              'flex',
+              'flex-col',
+              'justify-center',
+              'gap-y-2',
+              'md:ml-auto'
+            )}
+          >
+            <CopyAirdropHash hash={airdropHash} />
+            <ViewInBlockExplorer hash={airdropHash} />
+          </div>
+        </div>
+      </Box>
+    </div>
+  )
+}
+
+function CopyAirdropHash({ hash }: { hash: string }) {
+  const [isCopied, setCopied] = useClipboard(hash, {
+    successDuration: 4000,
+  })
+
+  const { start, end } =
+    hash?.match(/^(?<start>.{4}).+(?<end>.{4})$/)?.groups ?? {}
+  const truncatedHash = start && end ? `${start}...${end}` : null
+
+  if (!truncatedHash) {
+    return null
+  }
+
+  return (
+    <div
+      className={clsx('cursor-pointer', 'relative', styles.copyWrapper)}
+      role="button"
+      onClick={setCopied}
+    >
+      <div className={clsx(styles.tooltip)}>
+        {isCopied ? 'Copied!' : 'Copy to Clipboard'}
+      </div>
+      <InfoChip variant="airdrop" className="w-full">
+        <div className="flex items-center">
+          Airdrop: {truncatedHash}
+          <ActivityCopy className="ml-2" color="#5FC89A" />
+        </div>
+      </InfoChip>
+    </div>
+  )
+}
+
+function ViewInBlockExplorer({ hash }: { hash: string }) {
+  return (
+    <a
+      href={`https://explorer.ironfish.network/transaction/${hash}`}
+      target="_blank"
+      rel="noreferrer"
+    >
+      <InfoChip variant="airdrop" className="w-full">
+        <div className="flex items-center">
+          Block Explorer
+          <svg
+            className="ml-2"
+            xmlns="http://www.w3.org/2000/svg"
+            width={10}
+            height={9}
+            fill="none"
+          >
+            <path
+              fill="#5FC89A"
+              d="m1.633 8.9-.7-.7L7.8 1.333H1.5v-1h8v8h-1v-6.3L1.633 8.9Z"
+            />
+          </svg>
+        </div>
+      </InfoChip>
+    </a>
+  )
+}

--- a/components/Airdrop/TotalRewards/TotalRewards.tsx
+++ b/components/Airdrop/TotalRewards/TotalRewards.tsx
@@ -23,7 +23,7 @@ const longestPoolName = Object.values(titlesByPhase).sort(
 )[0]
 
 export function TotalRewards({ totalPoints, totalIron, airdropHash }: Props) {
-  if (!totalPoints || !totalIron || !airdropHash) {
+  if (!airdropHash) {
     return null
   }
 

--- a/components/Airdrop/TotalRewards/totalRewards.module.css
+++ b/components/Airdrop/TotalRewards/totalRewards.module.css
@@ -1,0 +1,30 @@
+.copyWrapper:hover .tooltip {
+  opacity: 1;
+}
+
+.tooltip {
+  font-size: 0.8rem;
+  position: absolute;
+  bottom: 100%;
+  color: black;
+  background: white;
+  padding: 0.25rem 0.5rem;
+  white-space: nowrap;
+  left: 50%;
+  transform: translateX(-50%) translateY(-15px);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.tooltip::after {
+  content: '';
+  position: absolute;
+  display: block;
+  width: 10px;
+  height: 10px;
+  top: 100%;
+  background-image: linear-gradient(to right bottom, transparent 50%, white 0);
+  left: 50%;
+  transform: translateX(-50%) translateY(-5px) rotate(45deg);
+}

--- a/components/Airdrop/types/JumioTypes.ts
+++ b/components/Airdrop/types/JumioTypes.ts
@@ -27,6 +27,7 @@ export type JumioWorkflow = {
   pool_two_iron?: number
   pool_three_iron?: number
   pool_four_iron?: number
+  airdrop_transaction_hash?: string | null
 }
 
 export type KycConfigPool = {

--- a/components/icons/ActivityCopy.tsx
+++ b/components/icons/ActivityCopy.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 
 type ActivityProps = {
   className: string
+  color?: string
 }
 
-function ActivityCopy({ className = '' }: ActivityProps) {
+function ActivityCopy({ className = '', color = '#7F7F7F' }: ActivityProps) {
   return (
     <svg
       className={className}
@@ -16,7 +17,7 @@ function ActivityCopy({ className = '' }: ActivityProps) {
     >
       <path
         d="M8 0.5H2C1.45 0.5 1 0.95 1 1.5V8.5H2V1.5H8V0.5ZM9.5 2.5H4C3.45 2.5 3 2.95 3 3.5V10.5C3 11.05 3.45 11.5 4 11.5H9.5C10.05 11.5 10.5 11.05 10.5 10.5V3.5C10.5 2.95 10.05 2.5 9.5 2.5ZM9.5 10.5H4V3.5H9.5V10.5Z"
-        fill="#7F7F7F"
+        fill={color}
       />
     </svg>
   )

--- a/pages/dashboard/rewards/index.tsx
+++ b/pages/dashboard/rewards/index.tsx
@@ -21,6 +21,8 @@ import { useApprovalStatusChip } from 'components/Airdrop/hooks/useApprovalStatu
 import { useGetKycStatus } from 'components/Airdrop/hooks/useGetKycStatus'
 import { useGetKycConfig } from 'components/Airdrop/hooks/useGetKycConfig'
 import WalletAddress from 'components/Airdrop/WalletAddress/WalletAddress'
+import { useMemo } from 'react'
+import { TotalRewards } from 'components/Airdrop/TotalRewards/TotalRewards'
 
 type AboutProps = {
   showNotification: boolean
@@ -49,6 +51,12 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
   const kycAttempts = kycStatus.response?.kyc_attempts ?? 0
   const kycMaxAttempts = kycStatus.response?.kyc_max_attempts ?? 3
   const canAttemptKyc = kycStatus.response?.can_attempt
+
+  const totalIron = useMemo(() => {
+    return Object.values(POOL_NAME_TO_IRON_REWARD).reduce((acc, poolName) => {
+      return acc + (kycStatus.response?.[poolName] ?? 0)
+    }, 0)
+  }, [kycStatus.response])
 
   const needsKyc =
     canAttemptKyc &&
@@ -214,6 +222,13 @@ export default function KYC({ showNotification, loginContext }: AboutProps) {
                   <div className="mb-16" />
                   <h2 className={clsx('text-3xl', 'mb-8')}>Your Rewards</h2>
                   <div className={clsx('flex', 'flex-col', 'gap-y-4')}>
+                    <TotalRewards
+                      totalPoints={userAllTimeMetrics?.points ?? 0}
+                      totalIron={totalIron === 0 ? null : totalIron}
+                      airdropHash={
+                        kycStatus?.response?.airdrop_transaction_hash ?? null
+                      }
+                    />
                     {kycConfig.data.map((pool, i) => {
                       const tokenKey = POOL_NAME_TO_IRON_REWARD[pool.name]
                       return (


### PR DESCRIPTION
## Summary

Adds component that shows user's airdrop transaction and total rewards.

<img width="1262" alt="Screenshot 2023-04-19 at 7 04 36 PM" src="https://user-images.githubusercontent.com/3639170/233231503-daba222f-d8aa-459f-a136-a01bf8a37074.png">

## Testing Plan

Manual testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
