### PR TITLE
feat: disable edit button for public address

### DIFF
--- a/components/Airdrop/WalletAddress/WalletAddress.tsx
+++ b/components/Airdrop/WalletAddress/WalletAddress.tsx
@@ -86,12 +86,6 @@ export default function WalletAddress({ address }: { address: string }) {
             'md:items-center'
           )}
         >
-          <button
-            onClick={() => setIsEditing(true)}
-            className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold ring-1 ring-inset ring-gray-300 sm:mt-0 sm:w-auto hover:bg-gray-50"
-          >
-            Edit
-          </button>
           <div
             className={clsx(
               'py-2',


### PR DESCRIPTION
## Summary
Removes button since we have already set addresses for airdrop.
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
